### PR TITLE
Keep the exposed API as putObject

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,5 @@ install:
 - stack --no-terminal --install-ghc test --only-dependencies
 
 script:
-# Download Minio Server
-- wget -q "https://dl.minio.io/server/minio/release/linux-amd64/minio" && chmod +x ./minio
-# Run server in background.
-- MINIO_ACCESS_KEY=minio MINIO_SECRET_KEY=minio123 ./minio server /tmp/export &
 # Build the package, its tests, and its docs and run the tests
-- stack --no-terminal test --haddock --no-haddock-deps
+- stack --no-terminal test --test-arguments "-p \"Unit tests common\"" --haddock --no-haddock-deps

--- a/README.md
+++ b/README.md
@@ -24,12 +24,11 @@ stack test
 
 ```
 
-A section of the tests require a live Minio server, running on `http://localhost:9000`
+A section of the tests use `https://play.minio.io:9000`.
 
 Documentation can be locally built with:
 
-
-``` shell
+```sh
 
 stack haddock
 

--- a/examples/putObject.hs
+++ b/examples/putObject.hs
@@ -21,12 +21,12 @@ main = do
       object = "obj"
       mb15 = 15 * 1024 * 1024
 
-  -- Eg 1. Upload a stream of repeating "a" using putObjectFromSource.
+  -- Eg 1. Upload a stream of repeating "a" using putObject.
   res1 <- runResourceT $ runMinio minioPlayCI $ do
-    putObjectFromSource bucket object (CC.repeat "a") (Just mb15)
+    putObject bucket object (CC.repeat "a") (Just mb15)
   case res1 of
-    Left e -> putStrLn $ "putObjectFromSource failed." ++ (show e)
-    Right () -> putStrLn "putObjectFromSource succeeded."
+    Left e -> putStrLn $ "putObject failed." ++ (show e)
+    Right () -> putStrLn "putObject succeeded."
 
 
   -- Eg 2. Upload a file using fPutObject.

--- a/src/Network/Minio.hs
+++ b/src/Network/Minio.hs
@@ -43,7 +43,7 @@ module Network.Minio
   ----------------------
   , fGetObject
   , fPutObject
-  , putObjectFromSource
+  , putObject
 
   , getObject
   , statObject
@@ -75,7 +75,7 @@ fGetObject bucket object fp = do
 
 -- | Upload the given file to the given object.
 fPutObject :: Bucket -> Object -> FilePath -> Minio ()
-fPutObject bucket object f = void $ putObject bucket object $
+fPutObject bucket object f = void $ putObjectFromSource bucket object $
                              ODFile f Nothing
 
 -- | Put an object from a conduit source. The size can be provided if
@@ -83,9 +83,9 @@ fPutObject bucket object f = void $ putObject bucket object $
 -- performing a multipart upload. If not specified, it is assumed that
 -- the object can be potentially 5TiB and selects multipart sizes
 -- appropriately.
-putObjectFromSource :: Bucket -> Object -> C.Producer Minio ByteString
+putObject :: Bucket -> Object -> C.Producer Minio ByteString
                     -> Maybe Int64 -> Minio ()
-putObjectFromSource bucket object src sizeMay = void $ putObject bucket object $
+putObject bucket object src sizeMay = void $ putObjectFromSource bucket object $
                                                 ODStream src sizeMay
 
 -- | Get an object from the object store as a resumable source (conduit).

--- a/src/Network/Minio/Data.hs
+++ b/src/Network/Minio/Data.hs
@@ -27,7 +27,7 @@ data ConnectInfo = ConnectInfo {
   } deriving (Eq, Show)
 
 instance Default ConnectInfo where
-  def = ConnectInfo "localhost" 9000 "minio" "minio123" False "us-east-1"
+  def = ConnectInfo "play.minio.io" 9000 "Q3AM3UQ867SPQQA43P2F" "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG" True "us-east-1"
 
 -- |
 -- Default aws ConnectInfo. Credentials should be supplied before use.

--- a/src/Network/Minio/PutObject.hs
+++ b/src/Network/Minio/PutObject.hs
@@ -1,6 +1,6 @@
 module Network.Minio.PutObject
   (
-    putObject
+    putObjectFromSource
   , ObjectData(..)
   , selectPartSizes
   ) where
@@ -49,9 +49,9 @@ data ObjectData m = ODFile FilePath (Maybe Int64) -- ^ Takes filepath and option
 
 -- | Put an object from ObjectData. This high-level API handles
 -- objects of all sizes, and even if the object size is unknown.
-putObject :: Bucket -> Object -> ObjectData Minio -> Minio ETag
-putObject b o (ODStream src sizeMay) = sequentialMultipartUpload b o sizeMay src
-putObject b o (ODFile fp sizeMay) = do
+putObjectFromSource :: Bucket -> Object -> ObjectData Minio -> Minio ETag
+putObjectFromSource b o (ODStream src sizeMay) = sequentialMultipartUpload b o sizeMay src
+putObjectFromSource b o (ODFile fp sizeMay) = do
   hResE <- withNewHandle fp $ \h ->
     liftM2 (,) (isHandleSeekable h) (getFileSize h)
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -188,7 +188,7 @@ liveServerUnitTests = testGroup "Unit tests against a live server"
       rFile <- mkRandFile mb100
 
       step "Upload multipart file."
-      putObjectFromSource bucket obj (CB.sourceFile rFile) Nothing
+      putObject bucket obj (CB.sourceFile rFile) Nothing
 
       step "Retrieve and verify file size"
       destFile <- mkRandFile 0
@@ -206,7 +206,7 @@ liveServerUnitTests = testGroup "Unit tests against a live server"
           mb100 = 100 * 1024 * 1024
 
       step "Upload multipart file."
-      void $ putObject bucket obj $ ODFile "/dev/zero" (Just mb100)
+      void $ putObjectFromSource bucket obj $ ODFile "/dev/zero" (Just mb100)
 
       step "Retrieve and verify file size"
       destFile <- mkRandFile 0
@@ -250,7 +250,7 @@ liveServerUnitTests = testGroup "Unit tests against a live server"
   , funTestWithBucket "multipart" $ \step bucket -> do
 
       step "upload large object"
-      void $ putObject bucket "big" (ODFile "/dev/zero" $ Just $ 1024*1024*100)
+      void $ putObjectFromSource bucket "big" (ODFile "/dev/zero" $ Just $ 1024*1024*100)
 
       step "cleanup"
       deleteObject bucket "big"
@@ -343,4 +343,4 @@ liveServerUnitTests = testGroup "Unit tests against a live server"
   ]
 
 unitTests :: TestTree
-unitTests = testGroup "Unit tests" [xmlGeneratorTests, xmlParserTests]
+unitTests = testGroup "Unit tests offline" [xmlGeneratorTests, xmlParserTests]


### PR DESCRIPTION
exposed API should match our other libraries. Also default SDK tests to run on play.minio.io