### PR TITLE
Add support to run tests against a locally running minio server

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,12 @@ stack test
 
 ```
 
-A section of the tests use `https://play.minio.io:9000`.
+A section of the tests use the remote Minio Play server at
+`https://play.minio.io:9000` by default. For library development,
+using this remote server maybe slow. To run the tests against a
+locally running Minio live server at `http://localhost:9000`, just set
+the environment `MINIO_LOCAL` to any value (and unset it to switch
+back to Play).
 
 Documentation can be locally built with:
 

--- a/test/LiveServer.hs
+++ b/test/LiveServer.hs
@@ -16,6 +16,7 @@ import qualified Data.Conduit.Binary as CB
 import           Data.Conduit.Combinators (sinkList)
 import           Data.Default (Default(..))
 import qualified Data.Text as T
+import           System.Environment (lookupEnv)
 
 import           Network.Minio
 import           Network.Minio.Data
@@ -62,7 +63,8 @@ funTestWithBucket t minioTest = testCaseSteps t $ \step -> do
   bktSuffix <- liftIO $ generate $ Q.vectorOf 10 (Q.choose ('a', 'z'))
   let b = T.concat [funTestBucketPrefix, T.pack bktSuffix]
       liftStep = liftIO . step
-  ret <- runResourceT $ runMinio minioPlayCI $ do
+  connInfo <- maybe minioPlayCI (const def) <$> lookupEnv "MINIO_LOCAL"
+  ret <- runResourceT $ runMinio connInfo $ do
     liftStep $ "Creating bucket for test - " ++ t
     makeBucket b def
     minioTest liftStep b


### PR DESCRIPTION
Enable via setting MINIO_LOCAL environment variable during tests.