### PR TITLE
Use multipart copy in copyObject smaller files:

### DIFF
--- a/src/Network/Minio.hs
+++ b/src/Network/Minio.hs
@@ -32,6 +32,7 @@ module Network.Minio
   , ObjectPartInfo(..)
   , UploadId
   , ObjectData(..)
+  , CopyPartSource(..)
 
   -- * Bucket Operations
   ----------------------

--- a/src/Network/Minio/PutObject.hs
+++ b/src/Network/Minio/PutObject.hs
@@ -213,15 +213,16 @@ copyObjectInternal b' o cps = do
             snd range >= fromIntegral srcSize]) $
     throwM $ ValidationError $ MErrVInvalidSrcObjByteRange range
 
-  -- 1. If sz > 5gb use multipart copy
+  -- 1. If sz > 64MiB (minPartSize) use multipart copy, OR
   -- 2. If startOffset /= 0 use multipart copy
   let destSize = (\(a, b) -> b - a + 1 ) $
                  maybe (0, srcSize - 1) identity $ cpSourceRange cps
       startOffset = maybe 0 fst $ cpSourceRange cps
       endOffset = maybe (srcSize - 1) snd $ cpSourceRange cps
 
-  if destSize > maxObjectPartSize || (endOffset - startOffset + 1 /= srcSize)
+  if destSize > minPartSize || (endOffset - startOffset + 1 /= srcSize)
     then multiPartCopyObject b' o cps srcSize
+
     else fst <$> copyObjectSingle b' o cps{cpSourceRange = Nothing} []
 
   where


### PR DESCRIPTION
This change makes copyObject use multipart strategy when the object to
be created has a size larger than 64 MiB. Previously this strategy was
used when the object is larger than 5GiB only.