### PR TITLE
Export ListUploadsResult and ListObjectsResult

### DIFF
--- a/src/Network/Minio/Data.hs
+++ b/src/Network/Minio/Data.hs
@@ -233,7 +233,7 @@ data ObjectInfo = ObjectInfo {
   } deriving (Show, Eq)
 
 data CopyPartSource = CopyPartSource {
-    cpSource :: Text -- | formatted like "/sourceBucket/sourceObject"
+    cpSource :: Text -- | formatted like "\/sourceBucket\/sourceObject"
   , cpSourceRange :: Maybe (Int64, Int64) -- | (0, 9) means first ten
                                           -- bytes of the source
                                           -- object

--- a/src/Network/Minio/ListOps.hs
+++ b/src/Network/Minio/ListOps.hs
@@ -35,7 +35,7 @@ listObjects bucket prefix recurse = loop Nothing
       let
         delimiter = bool (Just "/") Nothing recurse
 
-      res <- lift $ listObjects' bucket prefix nextToken delimiter
+      res <- lift $ listObjects' bucket prefix nextToken delimiter Nothing
       CL.sourceList $ lorObjects res
       when (lorHasMore res) $
         loop (lorNextToken res)
@@ -53,7 +53,7 @@ listIncompleteUploads bucket prefix recurse = loop Nothing Nothing
         delimiter = bool (Just "/") Nothing recurse
 
       res <- lift $ listIncompleteUploads' bucket prefix delimiter
-             nextKeyMarker nextUploadIdMarker
+             nextKeyMarker nextUploadIdMarker Nothing
 
       aggrSizes <- lift $ forM (lurUploads res) $ \(uKey, uId, _) -> do
             partInfos <- listIncompleteParts bucket uKey uId C.$$ CC.sinkList

--- a/src/Network/Minio/S3API.hs
+++ b/src/Network/Minio/S3API.hs
@@ -25,7 +25,7 @@ module Network.Minio.S3API
 
   -- * Listing objects
   --------------------
-  , ListObjectsResult
+  , ListObjectsResult(..)
   , listObjects'
 
   -- * Retrieving buckets
@@ -54,7 +54,7 @@ module Network.Minio.S3API
   , copyObjectPart
   , completeMultipartUpload
   , abortMultipartUpload
-  , ListUploadsResult
+  , ListUploadsResult(..)
   , listIncompleteUploads'
   , ListPartsResult(..)
   , listIncompleteParts'
@@ -145,9 +145,9 @@ putObjectSingle bucket object headers h offset size = do
 
 -- | List objects in a bucket matching prefix up to delimiter,
 -- starting from nextToken.
-listObjects' :: Bucket -> Maybe Text -> Maybe Text -> Maybe Text
+listObjects' :: Bucket -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Int
             -> Minio ListObjectsResult
-listObjects' bucket prefix nextToken delimiter = do
+listObjects' bucket prefix nextToken delimiter maxKeys = do
   resp <- executeRequest $ def { riMethod = HT.methodGet
                                , riBucket = Just bucket
                                , riQueryParams = mkOptionalParams params
@@ -159,6 +159,7 @@ listObjects' bucket prefix nextToken delimiter = do
       , ("continuation_token", nextToken)
       , ("prefix", prefix)
       , ("delimiter", delimiter)
+      , ("max-keys", show <$> maxKeys)
       ]
 
 -- | DELETE a bucket from the service.
@@ -278,8 +279,8 @@ abortMultipartUpload bucket object uploadId = void $
 
 -- | List incomplete multipart uploads.
 listIncompleteUploads' :: Bucket -> Maybe Text -> Maybe Text -> Maybe Text
-                       -> Maybe Text -> Minio ListUploadsResult
-listIncompleteUploads' bucket prefix delimiter keyMarker uploadIdMarker = do
+                       -> Maybe Text -> Maybe Int -> Minio ListUploadsResult
+listIncompleteUploads' bucket prefix delimiter keyMarker uploadIdMarker maxKeys = do
   resp <- executeRequest $ def { riMethod = HT.methodGet
                                , riBucket = Just bucket
                                , riQueryParams = params
@@ -292,6 +293,7 @@ listIncompleteUploads' bucket prefix delimiter keyMarker uploadIdMarker = do
              , ("delimiter", delimiter)
              , ("key-marker", keyMarker)
              , ("upload-id-marker", uploadIdMarker)
+             , ("max-uploads", show <$> maxKeys)
              ]
 
 

--- a/test/LiveServer.hs
+++ b/test/LiveServer.hs
@@ -241,7 +241,7 @@ liveServerUnitTests = testGroup "Unit tests against a live server"
         fPutObject bucket (T.concat ["lsb-release", T.pack (show s)]) "/etc/lsb-release"
 
       step "Simple list"
-      res <- listObjects' bucket Nothing Nothing Nothing
+      res <- listObjects' bucket Nothing Nothing Nothing Nothing
       let expected = sort $ map (T.concat .
                           ("lsb-release":) .
                           (\x -> [x]) .
@@ -262,7 +262,7 @@ liveServerUnitTests = testGroup "Unit tests against a live server"
 
       step "list incomplete multipart uploads"
       incompleteUploads <- listIncompleteUploads' bucket Nothing Nothing
-                           Nothing Nothing
+                           Nothing Nothing Nothing
       liftIO $ (length $ lurUploads incompleteUploads) @?= 10
 
       step "cleanup"


### PR DESCRIPTION
also take max-uploads as an argument for listIncompleteUploads' and max-keys for listObjects'

Fixes #47 
Fixes #46 