### PR TITLE
Fix concurrency bug in `limitedMapConcurrently`

### DIFF
--- a/examples/FileUploader.hs
+++ b/examples/FileUploader.hs
@@ -57,7 +57,7 @@ main :: IO ()
 main = do
   let bucket = "my-bucket"
 
-  -- Parse command line argument, namely --filename.
+  -- Parse command line argument
   filepath <- execParser cmdParser
   let object = pack $ takeBaseName filepath
 

--- a/minio-hs.cabal
+++ b/minio-hs.cabal
@@ -106,6 +106,7 @@ test-suite minio-hs-live-server-test
                      , Network.Minio.S3API
                      , Network.Minio.Sign.V4
                      , Network.Minio.Utils
+                     , Network.Minio.Utils.Test
                      , Network.Minio.API.Test
                      , Network.Minio.XmlGenerator
                      , Network.Minio.XmlGenerator.Test
@@ -215,6 +216,7 @@ test-suite minio-hs-test
                      , Network.Minio.S3API
                      , Network.Minio.Sign.V4
                      , Network.Minio.Utils
+                     , Network.Minio.Utils.Test
                      , Network.Minio.API.Test
                      , Network.Minio.XmlGenerator
                      , Network.Minio.XmlGenerator.Test

--- a/test/Network/Minio/Utils/Test.hs
+++ b/test/Network/Minio/Utils/Test.hs
@@ -1,0 +1,47 @@
+--
+-- Minio Haskell SDK, (C) 2017 Minio, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+module Network.Minio.Utils.Test
+  (
+    limitedMapConcurrentlyTests
+  ) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Lib.Prelude
+
+import Network.Minio.Utils
+
+limitedMapConcurrentlyTests :: TestTree
+limitedMapConcurrentlyTests = testGroup "limitedMapConcurrently Tests"
+  [ testCase "Test with various thread counts" testLMC
+  ]
+
+testLMC :: Assertion
+testLMC = do
+  let maxNum = 50
+  -- test with thread count of 1 to 2*maxNum
+  forM_ [1..(2*maxNum)] $ \threads -> do
+    res <- limitedMapConcurrently threads compute [1..maxNum]
+    sum res @?= overallResultCheck maxNum
+  where
+    -- simple function to run in each thread
+    compute :: Int -> IO Int
+    compute n = return $ sum [1..n]
+
+    -- function to check overall result
+    overallResultCheck n = sum $ map (\t -> (t * (t+1)) `div` 2) [1..n]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -23,6 +23,7 @@ import           Lib.Prelude
 
 import           Network.Minio.API.Test
 import           Network.Minio.PutObject
+import           Network.Minio.Utils.Test
 import           Network.Minio.XmlGenerator.Test
 import           Network.Minio.XmlParser.Test
 
@@ -113,4 +114,5 @@ qcProps = testGroup "(checked by QuickCheck)"
 unitTests :: TestTree
 unitTests = testGroup "Unit tests" [xmlGeneratorTests, xmlParserTests,
                                     bucketNameValidityTests,
-                                    objectNameValidityTests]
+                                    objectNameValidityTests,
+                                    limitedMapConcurrentlyTests]


### PR DESCRIPTION
Also simplifies implementation using lifted `bracket_` and async
routines, instead of lifted control operations like `liftBaseOp_`