### PR TITLE
Make copyObject use SourceInfo, DestinationInfo

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -557,31 +557,38 @@ main = do
 ```
 
 <a name="copyObject"></a>
-### copyObject :: Bucket -> Object -> CopyPartSource -> Minio ()
+### copyObject :: DestinationInfo -> SourceInfo -> Minio ()
 Copies content of an object from the service to another
 
 __Parameters__
 
-In the expression `copyObject bucketName objectName cps` the parameters
+In the expression `copyObject dstInfo srcInfo` the parameters
 are:
 
 |Param   |Type   |Description   |
 |:---|:---| :---|
-| `bucketName`  | _Bucket_ (alias for `Text`)  | Name of the bucket |
-| `objectName` | _Object_ (alias for `Text`)  | Name of the object |
-| `cps` | _CopyPartSource_ | A value representing properties of the source object |
+| `dstInfo` | _DestinationInfo_ | A value representing properties of the destination object |
+| `srcInfo` | _SourceInfo_ | A value representing properties of the source object |
 
 
-__CopyPartSource record type__
+__SourceInfo record type__
 
 |Field   |Type   |Description   |
 |:---|:---| :---|
-| `cpSource` | `Text`| Name of source object formatted as "/srcBucket/srcObject" |
-| `cpSourceRange` | `Maybe (Int64, Int64)` | Represents the byte range of source object. (0, 9) represents first ten bytes of source object|
-| `cpSourceIfMatch` | `Maybe Text` | (Optional) ETag source object should match |
-| `cpSourceIfNoneMatch` | `Maybe Text` | (Optional) ETag source object shouldn't match |
-| `cpSourceIfUnmodifiedSince` | `Maybe UTCTime` | (Optional) Time since source object wasn't modified |
-| `cpSourceIfModifiedSince` | `Maybe UTCTime` | (Optional) Time since source object was modified |
+| `srcBucket` | `Bucket` | Name of source bucket |
+| `srcObject` | `Object` | Name of source object |
+| `srcRange` | `Maybe (Int64, Int64)` | (Optional) Represents the byte range of source object. (0, 9) represents first ten bytes of source object|
+| `srcIfMatch` | `Maybe Text` | (Optional) ETag source object should match |
+| `srcIfNoneMatch` | `Maybe Text` | (Optional) ETag source object shouldn't match |
+| `srcIfUnmodifiedSince` | `Maybe UTCTime` | (Optional) Time since source object wasn't modified |
+| `srcIfModifiedSince` | `Maybe UTCTime` | (Optional) Time since source object was modified |
+
+__Destination record type__
+
+|Field   |Type   |Description   |
+|:---|:---| :---|
+| `dstBucket` | `Bucket` | Name of destination bucket in server-side copyObject |
+| `dstObject` | `Object` | Name of destination object in server-side copyObject |
 
 __Example__
 
@@ -594,13 +601,13 @@ main = do
   let
     bucket = "mybucket"
     object = "myobject"
-    srcObject = "/mybucket/srcObject"
+    objectCopy = "obj-copy"
 
   res <- runMinio minioPlayCI $ do
-           copyObject bucket object def { cpSource = srcObject }
+           copyObject def { dstBucket = bucket, dstObject = objectCopy } def { srcBucket = bucket, srcObject = object }
 
   case res of
-    Left e -> putStrLn $ "Failed to copyObject " ++ show srcObject"
+    Left e -> putStrLn $ "Failed to copyObject " ++ show bucket ++ show "/" ++ show object
     Right _ -> putStrLn "copyObject was successful"
 ```
 

--- a/examples/CopyObject.hs
+++ b/examples/CopyObject.hs
@@ -55,5 +55,5 @@ main = do
       }
 
   case res1 of
-    Left e   -> putStrLn $ "copyObject failed." ++ (show e)
+    Left e   -> putStrLn $ "copyObject failed." ++ show e
     Right () -> putStrLn "copyObject succeeded."

--- a/examples/CopyObject.hs
+++ b/examples/CopyObject.hs
@@ -21,7 +21,6 @@
 import           Network.Minio
 
 import           Control.Monad.Catch (catchIf)
-import qualified Data.Text           as T
 import           Prelude
 
 -- | The following example uses minio's play server at
@@ -50,9 +49,7 @@ main = do
     fPutObject bucket object localFile
 
     -- 3. Copy bucket/object to bucket/objectCopy.
-    copyObject bucket objectCopy def {
-      cpSource = T.concat ["/", bucket, "/", object]
-      }
+    copyObject def {dstBucket = bucket, dstObject = objectCopy} def { srcBucket = bucket , srcObject = object }
 
   case res1 of
     Left e   -> putStrLn $ "copyObject failed." ++ show e

--- a/minio-hs.cabal
+++ b/minio-hs.cabal
@@ -34,6 +34,7 @@ library
                      , Network.Minio.Data.ByteString
                      , Network.Minio.Data.Crypto
                      , Network.Minio.Data.Time
+                     , Network.Minio.CopyObject
                      , Network.Minio.Errors
                      , Network.Minio.ListOps
                      , Network.Minio.PresignedOperations
@@ -110,6 +111,7 @@ test-suite minio-hs-live-server-test
   other-modules:       Lib.Prelude
                      , Network.Minio
                      , Network.Minio.API
+                     , Network.Minio.CopyObject
                      , Network.Minio.Data
                      , Network.Minio.Data.ByteString
                      , Network.Minio.Data.Crypto
@@ -232,6 +234,7 @@ test-suite minio-hs-test
                      , Network.Minio.Data.ByteString
                      , Network.Minio.Data.Crypto
                      , Network.Minio.Data.Time
+                     , Network.Minio.CopyObject
                      , Network.Minio.Errors
                      , Network.Minio.ListOps
                      , Network.Minio.PresignedOperations

--- a/src/Network/Minio.hs
+++ b/src/Network/Minio.hs
@@ -91,14 +91,18 @@ module Network.Minio
   , getObject
 
   -- ** Server-side copying
-  , CopyPartSource
-  , cpSource
-  , cpSourceIfMatch
-  , cpSourceIfNoneMatch
-  , cpSourceIfModifiedSince
-  , cpSourceIfUnmodifiedSince
-  , cpSourceRange
   , copyObject
+  , SourceInfo
+  , srcBucket
+  , srcObject
+  , srcRange
+  , srcIfMatch
+  , srcIfNoneMatch
+  , srcIfModifiedSince
+  , srcIfUnmodifiedSince
+  , DestinationInfo
+  , dstBucket
+  , dstObject
 
   -- ** Querying
   , statObject
@@ -185,12 +189,13 @@ putObject :: Bucket -> Object -> C.Producer Minio ByteString
 putObject bucket object src sizeMay =
   void $ putObjectInternal bucket object $ ODStream src sizeMay
 
--- | Perform a server-side copy operation to create an object with the
--- given bucket and object name from the source specification in
--- CopyPartSource. This function performs a multipart copy operation
--- if the new object is to be greater than 5GiB in size.
-copyObject :: Bucket -> Object -> CopyPartSource -> Minio ()
-copyObject bucket object cps = void $ copyObjectInternal bucket object cps
+-- | Perform a server-side copy operation to create an object based on
+-- the destination specification in DestinationInfo from the source
+-- specification in SourceInfo. This function performs a multipart
+-- copy operation if the new object is to be greater than 5GiB in
+-- size.
+copyObject :: DestinationInfo -> SourceInfo -> Minio ()
+copyObject dstInfo srcInfo = void $ copyObjectInternal (dstBucket dstInfo) (dstObject dstInfo) srcInfo
 
 -- | Remove an object from the object store.
 removeObject :: Bucket -> Object -> Minio ()

--- a/src/Network/Minio.hs
+++ b/src/Network/Minio.hs
@@ -91,7 +91,13 @@ module Network.Minio
   , getObject
 
   -- ** Server-side copying
-  , CopyPartSource(..)
+  , CopyPartSource
+  , cpSource
+  , cpSourceIfMatch
+  , cpSourceIfNoneMatch
+  , cpSourceIfModifiedSince
+  , cpSourceIfUnmodifiedSince
+  , cpSourceRange
   , copyObject
 
   -- ** Querying
@@ -146,6 +152,7 @@ import qualified Data.Map                 as Map
 
 import           Lib.Prelude
 
+import           Network.Minio.CopyObject
 import           Network.Minio.Data
 import           Network.Minio.Errors
 import           Network.Minio.ListOps

--- a/src/Network/Minio/CopyObject.hs
+++ b/src/Network/Minio/CopyObject.hs
@@ -1,0 +1,108 @@
+--
+-- Minio Haskell SDK, (C) 2017 Minio, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+module Network.Minio.CopyObject
+  (
+    copyObjectInternal
+  , selectCopyRanges
+  , multiPartCopyObject
+  ) where
+
+import qualified Data.List as List
+import qualified Data.Text as T
+
+import           Lib.Prelude
+
+import           Network.Minio.Data
+import           Network.Minio.Errors
+import           Network.Minio.S3API
+import           Network.Minio.Utils
+
+
+-- | Extract the source bucket and source object name. TODO: validate
+-- the bucket and object name extracted.
+cpsToObject :: CopyPartSource -> Maybe (Bucket, Object)
+cpsToObject cps = do
+  [_, bucket, object] <- Just splits
+  return (bucket, object)
+  where
+    splits = T.splitOn "/" $ cpSource cps
+
+-- | Copy an object using single or multipart copy strategy.
+copyObjectInternal :: Bucket -> Object -> CopyPartSource
+                   -> Minio ETag
+copyObjectInternal b' o cps = do
+  -- validate and extract the src bucket and object
+  (srcBucket, srcObject) <- maybe
+    (throwM $ MErrVInvalidSrcObjSpec $ cpSource cps)
+    return $ cpsToObject cps
+
+  -- get source object size with a head request
+  (ObjectInfo _ _ _ srcSize) <- headObject srcBucket srcObject
+
+  -- check that byte offsets are valid if specified in cps
+  when (isJust (cpSourceRange cps) &&
+        or [fst range < 0, snd range < fst range,
+            snd range >= fromIntegral srcSize]) $
+    throwM $ MErrVInvalidSrcObjByteRange range
+
+  -- 1. If sz > 64MiB (minPartSize) use multipart copy, OR
+  -- 2. If startOffset /= 0 use multipart copy
+  let destSize = (\(a, b) -> b - a + 1 ) $
+                 maybe (0, srcSize - 1) identity $ cpSourceRange cps
+      startOffset = maybe 0 fst $ cpSourceRange cps
+      endOffset = maybe (srcSize - 1) snd $ cpSourceRange cps
+
+  if destSize > minPartSize || (endOffset - startOffset + 1 /= srcSize)
+    then multiPartCopyObject b' o cps srcSize
+
+    else fst <$> copyObjectSingle b' o cps{cpSourceRange = Nothing} []
+
+  where
+    range = maybe (0, 0) identity $ cpSourceRange cps
+
+-- | Given the input byte range of the source object, compute the
+-- splits for a multipart copy object procedure. Minimum part size
+-- used is minPartSize.
+selectCopyRanges :: (Int64, Int64) -> [(PartNumber, (Int64, Int64))]
+selectCopyRanges (st, end) = zip pns $
+  map (\(x, y) -> (st + x, st + x + y - 1)) $ zip startOffsets partSizes
+  where
+    size = end - st + 1
+    (pns, startOffsets, partSizes) = List.unzip3 $ selectPartSizes size
+
+-- | Perform a multipart copy object action. Since we cannot verify
+-- existing parts based on the source object, there is no resuming
+-- copy action support.
+multiPartCopyObject :: Bucket -> Object -> CopyPartSource -> Int64
+                    -> Minio ETag
+multiPartCopyObject b o cps srcSize = do
+  uid <- newMultipartUpload b o []
+
+  let byteRange = maybe (0, fromIntegral $ srcSize - 1) identity $
+                  cpSourceRange cps
+      partRanges = selectCopyRanges byteRange
+      partSources = map (\(x, y) -> (x, cps {cpSourceRange = Just y}))
+                    partRanges
+
+  copiedParts <- limitedMapConcurrently 10
+                 (\(pn, cps') -> do
+                     (etag, _) <- copyObjectPart b o cps' uid pn []
+                     return (pn, etag)
+                 )
+                 partSources
+
+  completeMultipartUpload b o uid copiedParts

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -22,6 +22,8 @@ import qualified Data.List as L
 import           Lib.Prelude
 
 import           Network.Minio.API.Test
+import           Network.Minio.CopyObject
+import           Network.Minio.Data
 import           Network.Minio.PutObject
 import           Network.Minio.Utils.Test
 import           Network.Minio.XmlGenerator.Test


### PR DESCRIPTION
* Allows adding additional record members to SourceInfo and DestinationInfo without breaking
applications (e.g, encryption related options).

* Move high-level copyObject functions to CopyObject module