### PR TITLE
Infer XML namespace using connectHost 

### DIFF
--- a/minio-hs.cabal
+++ b/minio-hs.cabal
@@ -119,6 +119,7 @@ test-suite minio-hs-live-server-test
                      , Network.Minio.PutObject
                      , Network.Minio.S3API
                      , Network.Minio.Sign.V4
+                     , Network.Minio.TestHelpers
                      , Network.Minio.Utils
                      , Network.Minio.Utils.Test
                      , Network.Minio.API.Test
@@ -225,6 +226,7 @@ test-suite minio-hs-test
                      , Network.Minio.PutObject
                      , Network.Minio.S3API
                      , Network.Minio.Sign.V4
+                     , Network.Minio.TestHelpers
                      , Network.Minio.Utils
                      , Network.Minio.Utils.Test
                      , Network.Minio.API.Test

--- a/src/Network/Minio.hs
+++ b/src/Network/Minio.hs
@@ -23,6 +23,7 @@ module Network.Minio
   ---------------------------------
     ConnectInfo(..)
   , awsCI
+  , gcsCI
 
   -- ** Connection helpers
   ------------------------

--- a/src/Network/Minio/S3API.hs
+++ b/src/Network/Minio/S3API.hs
@@ -133,11 +133,12 @@ getObject' bucket object queryParams headers = do
 
 -- | Creates a bucket via a PUT bucket call.
 putBucket :: Bucket -> Region -> Minio ()
-putBucket bucket location = void $
-  executeRequest $
+putBucket bucket location = do
+  ns <- asks getSvcNamespace
+  void $ executeRequest $
     def { riMethod = HT.methodPut
         , riBucket = Just bucket
-        , riPayload = PayloadBS $ mkCreateBucketConfig location
+        , riPayload = PayloadBS $ mkCreateBucketConfig ns location
         , riNeedsLocation = False
         }
 
@@ -445,12 +446,13 @@ headBucket bucket = headBucketEx `catches`
 
 -- | Set the notification configuration on a bucket.
 putBucketNotification :: Bucket -> Notification -> Minio ()
-putBucketNotification bucket ncfg =
+putBucketNotification bucket ncfg = do
+  ns <- asks getSvcNamespace
   void $ executeRequest $ def { riMethod = HT.methodPut
                               , riBucket = Just bucket
                               , riQueryParams = [("notification", Nothing)]
                               , riPayload = PayloadBS $
-                                            mkPutNotificationRequest ncfg
+                                            mkPutNotificationRequest ns ncfg
                               }
 
 -- | Retrieve the notification configuration on a bucket.

--- a/test/Network/Minio/TestHelpers.hs
+++ b/test/Network/Minio/TestHelpers.hs
@@ -1,0 +1,32 @@
+--
+-- Minio Haskell SDK, (C) 2018 Minio, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+module Network.Minio.TestHelpers
+  ( runTestNS
+  ) where
+
+import           Network.Minio.Data
+
+import           Lib.Prelude
+
+newtype TestNS = TestNS { testNamespace :: Text }
+
+instance HasSvcNamespace TestNS where
+  getSvcNamespace = testNamespace
+
+runTestNS :: ReaderT TestNS m a -> m a
+runTestNS = flip runReaderT $
+            TestNS "http://s3.amazonaws.com/doc/2006-03-01/"

--- a/test/Network/Minio/Utils/Test.hs
+++ b/test/Network/Minio/Utils/Test.hs
@@ -19,12 +19,12 @@ module Network.Minio.Utils.Test
     limitedMapConcurrentlyTests
   ) where
 
-import Test.Tasty
-import Test.Tasty.HUnit
+import           Test.Tasty
+import           Test.Tasty.HUnit
 
-import Lib.Prelude
+import           Lib.Prelude
 
-import Network.Minio.Utils
+import           Network.Minio.Utils
 
 limitedMapConcurrentlyTests :: TestTree
 limitedMapConcurrentlyTests = testGroup "limitedMapConcurrently Tests"

--- a/test/Network/Minio/XmlGenerator/Test.hs
+++ b/test/Network/Minio/XmlGenerator/Test.hs
@@ -26,6 +26,7 @@ import           Lib.Prelude
 import           Data.Default               (def)
 
 import           Network.Minio.Data
+import           Network.Minio.TestHelpers
 import           Network.Minio.XmlGenerator
 import           Network.Minio.XmlParser    (parseNotification)
 
@@ -38,8 +39,9 @@ xmlGeneratorTests = testGroup "XML Generator Tests"
 
 testMkCreateBucketConfig :: Assertion
 testMkCreateBucketConfig = do
+  let ns = "http://s3.amazonaws.com/doc/2006-03-01/"
   assertEqual "CreateBucketConfiguration xml should match: " expected $
-    mkCreateBucketConfig "EU"
+    mkCreateBucketConfig ns "EU"
   where
     expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
                \<CreateBucketConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
@@ -58,11 +60,13 @@ testMkCompleteMultipartUploadRequest =
     \</Part>\
     \</CompleteMultipartUpload>"
 
+
 testMkPutNotificationRequest :: Assertion
 testMkPutNotificationRequest =
   forM_ cases $ \val -> do
-    let result = toS $ mkPutNotificationRequest val
-    ntf <- runExceptT $ parseNotification result
+    let ns = "http://s3.amazonaws.com/doc/2006-03-01/"
+        result = toS $ mkPutNotificationRequest ns val
+    ntf <- runExceptT $ runTestNS $ parseNotification result
     either (\_ -> assertFailure "XML Parse Error!")
       (@?= val) ntf
   where


### PR DESCRIPTION
While GCS is S3 v4 compatible, it uses a different xml namespace url
than AWS (and Minio).