### PR TITLE
improve initializing ConnectInfo

### DIFF
--- a/minio-hs.cabal
+++ b/minio-hs.cabal
@@ -57,11 +57,12 @@ library
                      , containers >= 0.5
                      , cryptonite >= 0.25
                      , cryptonite-conduit >= 0.2
-                     , data-default >= 0.7
+                     , directory
                      , filepath >= 1.4
                      , http-client >= 0.5
                      , http-conduit >= 2.3
                      , http-types >= 0.12
+                     , ini
                      , memory >= 0.14
                      , resourcet >= 1.2
                      , text >= 1.2
@@ -142,12 +143,12 @@ test-suite minio-hs-live-server-test
                      , containers
                      , cryptonite
                      , cryptonite-conduit
-                     , data-default
                      , directory
                      , filepath
                      , http-client
                      , http-conduit
                      , http-types
+                     , ini
                      , memory
                      , QuickCheck
                      , resourcet
@@ -181,11 +182,12 @@ test-suite minio-hs-test
                      , containers
                      , cryptonite
                      , cryptonite-conduit
-                     , data-default
+                     , filepath
                      , directory
                      , http-client
                      , http-conduit
                      , http-types
+                     , ini
                      , memory
                      , QuickCheck
                      , resourcet

--- a/src/Network/Minio.hs
+++ b/src/Network/Minio.hs
@@ -18,18 +18,27 @@
 
 module Network.Minio
   (
+  -- * Credentials
+    Credentials (..)
+  , fromAWSConfigFile
+  , fromAWSEnv
+  , fromMinioEnv
 
   -- * Connecting to object storage
   ---------------------------------
-    ConnectInfo(..)
-  , awsCI
-  , gcsCI
+  , ConnectInfo
+  , setRegion
+  , setCreds
+  , setCredsFrom
+  , MinioConn
+  , mkMinioConn
 
   -- ** Connection helpers
   ------------------------
-  , awsWithRegionCI
   , minioPlayCI
-  , minioCI
+  , awsCI
+  , gcsCI
+
 
   -- * Minio Monad
   ----------------
@@ -39,8 +48,9 @@ module Network.Minio
   -- this Monad.
 
   , Minio
+  , runMinioWith
   , runMinio
-  , def
+
 
   -- * Bucket Operations
   ----------------------
@@ -76,12 +86,16 @@ module Network.Minio
 
   -- ** Bucket Notifications
   , Notification(..)
+  , defaultNotification
   , NotificationConfig(..)
   , Arn
   , Event(..)
   , Filter(..)
+  , defaultFilter
   , FilterKey(..)
+  , defaultFilterKey
   , FilterRules(..)
+  , defaultFilterRules
   , FilterRule(..)
   , getBucketNotification
   , putBucketNotification
@@ -99,6 +113,7 @@ module Network.Minio
   , putObject
   -- | Input data type represents PutObject options.
   , PutObjectOptions
+  , defaultPutObjectOptions
   , pooContentType
   , pooContentEncoding
   , pooContentDisposition
@@ -111,6 +126,7 @@ module Network.Minio
   , getObject
   -- | Input data type represents GetObject options.
   , GetObjectOptions
+  , defaultGetObjectOptions
   , gooRange
   , gooIfMatch
   , gooIfNoneMatch
@@ -120,6 +136,7 @@ module Network.Minio
   -- ** Server-side copying
   , copyObject
   , SourceInfo
+  , defaultSourceInfo
   , srcBucket
   , srcObject
   , srcRange
@@ -128,6 +145,7 @@ module Network.Minio
   , srcIfModifiedSince
   , srcIfUnmodifiedSince
   , DestinationInfo
+  , defaultDestinationInfo
   , dstBucket
   , dstObject
 
@@ -178,7 +196,6 @@ This module exports the high-level Minio API for object storage.
 import qualified Data.Conduit             as C
 import qualified Data.Conduit.Binary      as CB
 import qualified Data.Conduit.Combinators as CC
-import           Data.Default             (def)
 
 import           Lib.Prelude
 

--- a/src/Network/Minio/API.hs
+++ b/src/Network/Minio/API.hs
@@ -31,7 +31,6 @@ module Network.Minio.API
 import qualified Data.ByteString           as B
 import qualified Data.Char                 as C
 import qualified Data.Conduit              as C
-import           Data.Default              (def)
 import qualified Data.Map                  as Map
 import qualified Data.Text                 as T
 import qualified Data.Time.Clock           as Time
@@ -53,7 +52,7 @@ import           Network.Minio.XmlParser
 -- | Fetch bucket location (region)
 getLocation :: Bucket -> Minio Region
 getLocation bucket = do
-  resp <- executeRequest $ def {
+  resp <- executeRequest $ defaultS3ReqInfo {
       riBucket = Just bucket
     , riQueryParams = [("location", Nothing)]
     , riNeedsLocation = False

--- a/src/Network/Minio/CopyObject.hs
+++ b/src/Network/Minio/CopyObject.hs
@@ -16,7 +16,6 @@
 
 module Network.Minio.CopyObject where
 
-import           Data.Default         (def)
 import qualified Data.List            as List
 
 import           Lib.Prelude
@@ -81,7 +80,7 @@ multiPartCopyObject b o cps srcSize = do
       partRanges = selectCopyRanges byteRange
       partSources = map (\(x, (start, end)) -> (x, cps {srcRange = Just (start, end) }))
                     partRanges
-      dstInfo = def { dstBucket = b, dstObject = o}
+      dstInfo = defaultDestinationInfo { dstBucket = b, dstObject = o}
 
   copiedParts <- limitedMapConcurrently 10
                  (\(pn, cps') -> do

--- a/src/Network/Minio/Errors.hs
+++ b/src/Network/Minio/Errors.hs
@@ -40,6 +40,7 @@ data MErrV = MErrVSinglePUTSizeExceeded Int64
            | MErrVInvalidUrlExpiry Int
            | MErrVJsonParse Text
            | MErrVInvalidHealPath
+           | MErrVMissingCredentials
   deriving (Show, Eq)
 
 instance Exception MErrV

--- a/src/Network/Minio/Sign/V4.hs
+++ b/src/Network/Minio/Sign/V4.hs
@@ -43,7 +43,6 @@ import qualified Network.HTTP.Types.Header     as H
 
 import           Lib.Prelude
 
-import           Network.Minio.Data
 import           Network.Minio.Data.ByteString
 import           Network.Minio.Data.Crypto
 import           Network.Minio.Data.Time
@@ -72,7 +71,7 @@ data SignParams = SignParams {
       spAccessKey   :: Text
     , spSecretKey   :: Text
     , spTimeStamp   :: UTCTime
-    , spRegion      :: Maybe Region
+    , spRegion      :: Maybe Text
     , spExpirySecs  :: Maybe Int
     , spPayloadHash :: Maybe ByteString
     } deriving (Show)
@@ -174,7 +173,7 @@ signV4 !sp !req =
   in output
 
 
-mkScope :: UTCTime -> Region -> ByteString
+mkScope :: UTCTime -> Text -> ByteString
 mkScope ts region = B.intercalate "/"
   [ toS $ Time.formatTime Time.defaultTimeLocale "%Y%m%d" ts
   , toS region
@@ -222,7 +221,7 @@ mkStringToSign ts !scope !canonicalRequest = B.intercalate "\n"
                                              , hashSHA256 canonicalRequest
                                              ]
 
-mkSigningKey :: UTCTime -> Region -> ByteString -> ByteString
+mkSigningKey :: UTCTime -> Text -> ByteString -> ByteString
 mkSigningKey ts region !secretKey = hmacSHA256RawBS "aws4_request"
                                   . hmacSHA256RawBS "s3"
                                   . hmacSHA256RawBS (toS region)

--- a/test/Network/Minio/XmlGenerator/Test.hs
+++ b/test/Network/Minio/XmlGenerator/Test.hs
@@ -23,8 +23,6 @@ import           Test.Tasty.HUnit
 
 import           Lib.Prelude
 
-import           Data.Default               (def)
-
 import           Network.Minio.Data
 import           Network.Minio.TestHelpers
 import           Network.Minio.XmlGenerator
@@ -74,7 +72,7 @@ testMkPutNotificationRequest =
               [ NotificationConfig
                 "YjVkM2Y0YmUtNGI3NC00ZjQyLWEwNGItNDIyYWUxY2I0N2M4"
                 "arn:aws:sns:us-east-1:account-id:s3notificationtopic2"
-                [ReducedRedundancyLostObject, ObjectCreated] def
+                [ReducedRedundancyLostObject, ObjectCreated] defaultFilter
               ]
               []
             , Notification
@@ -86,14 +84,14 @@ testMkPutNotificationRequest =
                   , FilterRule "suffix" ".jpg"])
               , NotificationConfig
                 "" "arn:aws:sqs:us-east-1:356671443308:s3notificationqueue"
-                [ObjectCreated] def
+                [ObjectCreated] defaultFilter
               ]
               [ NotificationConfig
                 "" "arn:aws:sns:us-east-1:356671443308:s3notificationtopic2"
-                [ReducedRedundancyLostObject] def
+                [ReducedRedundancyLostObject] defaultFilter
               ]
               [ NotificationConfig
                 "ObjectCreatedEvents" "arn:aws:lambda:us-west-2:35667example:function:CreateThumbnail"
-                [ObjectCreated] def
+                [ObjectCreated] defaultFilter
               ]
             ]

--- a/test/Network/Minio/XmlParser/Test.hs
+++ b/test/Network/Minio/XmlParser/Test.hs
@@ -19,7 +19,6 @@ module Network.Minio.XmlParser.Test
     xmlParserTests
   ) where
 
-import           Data.Default              (def)
 import qualified Data.Map                  as Map
 import           Data.Time                 (fromGregorian)
 import           Test.Tasty
@@ -299,7 +298,7 @@ testParseNotification = do
                 [ NotificationConfig
                   "YjVkM2Y0YmUtNGI3NC00ZjQyLWEwNGItNDIyYWUxY2I0N2M4"
                   "arn:aws:sns:us-east-1:account-id:s3notificationtopic2"
-                  [ReducedRedundancyLostObject, ObjectCreated] def
+                  [ReducedRedundancyLostObject, ObjectCreated] defaultFilter
                 ]
                 [])
             , ("<NotificationConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
@@ -342,15 +341,15 @@ testParseNotification = do
                                 FilterRule "suffix" ".jpg"])
                             , NotificationConfig
                               "" "arn:aws:sqs:us-east-1:356671443308:s3notificationqueue"
-                              [ObjectCreated] def
+                              [ObjectCreated] defaultFilter
                             ]
                             [ NotificationConfig
                               "" "arn:aws:sns:us-east-1:356671443308:s3notificationtopic2"
-                              [ReducedRedundancyLostObject] def
+                              [ReducedRedundancyLostObject] defaultFilter
                             ]
                             [ NotificationConfig
                               "ObjectCreatedEvents" "arn:aws:lambda:us-west-2:35667example:function:CreateThumbnail"
-                              [ObjectCreated] def
+                              [ObjectCreated] defaultFilter
                             ])
             ]
 


### PR DESCRIPTION
- Remove ConnectInfo's Default instance
- Add support for reading from well-known credential files and
  environment variables

## TBD
- should we move `minioPlayCI`, `awsCI` etc to use `connectInfo` / `connectInfoWithCreds`?
- should we make then `IO ConnectInfo` as opposed to pure values?

##TODO
- [ ] update documentation
- [ ] add examples
