### PR TITLE
MinIO & min.io replaces Minio & minio.io respectively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ This release brings the following changes:
 This is a bug-fix release:
 
 * Fix concurrency bug in `limitedMapConcurrently` (#53)
-* Fix tests related to listing incomplete uploads to accommodate Minio
+* Fix tests related to listing incomplete uploads to accommodate MinIO
   server's changed behaviour to not list incomplete uploads. Note that
   running these tests against AWS S3 are expected to fail. (#54)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Minio Client SDK for Haskell [![Build Status](https://travis-ci.org/minio/minio-hs.svg?branch=master)](https://travis-ci.org/minio/minio-hs)[![Hackage](https://img.shields.io/hackage/v/minio-hs.svg)](https://hackage.haskell.org/package/minio-hs)[![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
+# MinIO Client SDK for Haskell [![Build Status](https://travis-ci.org/minio/minio-hs.svg?branch=master)](https://travis-ci.org/minio/minio-hs)[![Hackage](https://img.shields.io/hackage/v/minio-hs.svg)](https://hackage.haskell.org/package/minio-hs)[![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
 
-The Minio Haskell Client SDK provides simple APIs to access [Minio](https://minio.io) and Amazon S3 compatible object storage server.
+The MinIO Haskell Client SDK provides simple APIs to access [MinIO](https://min.io) and Amazon S3 compatible object storage server.
 
 ## Minimum Requirements
 
@@ -24,10 +24,10 @@ stack test
 
 ```
 
-A section of the tests use the remote Minio Play server at
-`https://play.minio.io:9000` by default. For library development,
+A section of the tests use the remote MinIO Play server at
+`https://play.min.io:9000` by default. For library development,
 using this remote server maybe slow. To run the tests against a
-locally running Minio live server at `http://localhost:9000`, just set
+locally running MinIO live server at `http://localhost:9000`, just set
 the environment `MINIO_LOCAL` to any value (and unset it to switch
 back to Play).
 
@@ -47,7 +47,7 @@ stack haddock
 -- stack --resolver lts-11.1 runghc --package minio-hs --package optparse-applicative --package filepath
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ import           UnliftIO              (throwIO, try)
 import           Prelude
 
 -- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo
@@ -86,7 +86,7 @@ import           Prelude
 fileNameArgs :: Parser FilePath
 fileNameArgs = strArgument
                (metavar "FILENAME"
-                <> help "Name of file to upload to AWS S3 or a Minio server")
+                <> help "Name of file to upload to AWS S3 or a MinIO server")
 
 cmdParser = info
             (helper <*> fileNameArgs)

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,8 +1,8 @@
-# Minio Haskell SDK API Reference
+# MinIO Haskell SDK API Reference
 
-## Initialize Minio Client object.
+## Initialize MinIO Client object.
 
-### Minio - for public Play server
+### MinIO - for public Play server
 
 ```haskell
 minioPlayCI :: ConnectInfo
@@ -32,8 +32,8 @@ awsCI { connectAccesskey = "your-access-key"
 
 ## 1. Connecting and running operations on the storage service
 
-The Haskell Minio SDK provides high-level functionality to perform
-operations on a Minio server or any AWS S3-like API compatible storage
+The Haskell MinIO SDK provides high-level functionality to perform
+operations on a MinIO server or any AWS S3-like API compatible storage
 service.
 
 ### The `ConnectInfo` type
@@ -77,18 +77,18 @@ The parameters in the expression `awsWithRegion region autoDiscover` are:
 #### minioPlayCI :: ConnectInfo
 
 This constructor provides connection and authentication information to
-connect to the public Minio Play server at
-`https://play.minio.io:9000/`.
+connect to the public MinIO Play server at
+`https://play.min.io:9000/`.
 
 #### minioCI :: Text -> Int -> Bool -> ConnectInfo
 
-Use to connect to a Minio server.
+Use to connect to a MinIO server.
 
 The parameters in the expression `minioCI host port isSecure` are:
 
 |Parameter|Type|Description|
 |:---|:---|:---|
-| `host` | _Text_ | Hostname of the Minio or other S3-API compatible server |
+| `host` | _Text_ | Hostname of the MinIO or other S3-API compatible server |
 | `port` | _Int_ | Port number to connect to|
 | `isSecure` | _Bool_ | Does the server use HTTPS? |
 
@@ -112,7 +112,7 @@ values.
 ### The Minio Monad
 
 This monad provides the required environment to perform requests
-against a Minio or other S3 API compatible server. It uses the
+against a MinIO or other S3 API compatible server. It uses the
 connection information from the `ConnectInfo` value provided to it. It
 performs connection pooling, bucket location caching, error handling
 and resource clean-up actions.
@@ -264,8 +264,8 @@ import           Conduit
 import           Prelude
 
 
--- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- | The following example uses MinIO play server at
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo
@@ -277,7 +277,7 @@ main = do
     bucket = "test"
 
   -- Performs a recursive listing of all objects under bucket "test"
-  -- on play.minio.io.
+  -- on play.min.io.
   res <- runMinio minioPlayCI $
     runConduit $ listObjects bucket Nothing True .| mapM_C (\v -> (liftIO $ print v))
   print res
@@ -325,8 +325,8 @@ import           Conduit
 import           Prelude
 
 
--- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- | The following example uses MinIO play server at
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo
@@ -338,7 +338,7 @@ main = do
     bucket = "test"
 
   -- Performs a recursive listing of all objects under bucket "test"
-  -- on play.minio.io.
+  -- on play.min.io.
   res <- runMinio minioPlayCI $
     runConduit $ listObjectsV1 bucket Nothing True .| mapM_C (\v -> (liftIO $ print v))
   print res
@@ -383,8 +383,8 @@ import           Network.Minio
 import           Conduit
 import           Prelude
 
--- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- | The following example uses MinIO play server at
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo
@@ -396,7 +396,7 @@ main = do
     bucket = "test"
 
   -- Performs a recursive listing of incomplete uploads under bucket "test"
-  -- on a local minio server.
+  -- on a local MinIO server.
   res <- runMinio minioPlayCI $
     runConduit $ listIncompleteUploads bucket Nothing True .| mapM_C (\v -> (liftIO $ print v))
   print res
@@ -450,8 +450,8 @@ import qualified Data.Conduit.Binary as CB
 
 import           Prelude
 
--- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- | The following example uses MinIO play server at
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo
@@ -500,8 +500,8 @@ import qualified Data.Conduit.Combinators as CC
 
 import           Prelude
 
--- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- | The following example uses MinIO play server at
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo
@@ -560,8 +560,8 @@ import Data.Conduit (($$+-))
 import Data.Conduit.Binary (sinkLbs)
 import Prelude
 
--- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- | The following example uses MinIO play server at
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo

--- a/examples/BucketExists.hs
+++ b/examples/BucketExists.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import Control.Monad.IO.Class (liftIO)
 import Prelude
 
 -- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo

--- a/examples/CopyObject.hs
+++ b/examples/CopyObject.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import           Control.Monad.Catch (catchIf)
 import           Prelude
 
 -- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo

--- a/examples/FileUploader.hs
+++ b/examples/FileUploader.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs --package optparse-applicative --package filepath
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import           UnliftIO              (throwIO, try)
 import           Prelude
 
 -- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo
@@ -41,7 +41,7 @@ import           Prelude
 fileNameArgs :: Parser FilePath
 fileNameArgs = strArgument
                (metavar "FILENAME"
-                <> help "Name of file to upload to AWS S3 or a Minio server")
+                <> help "Name of file to upload to AWS S3 or a MinIO server")
 
 cmdParser = info
             (helper <*> fileNameArgs)

--- a/examples/GetConfig.hs
+++ b/examples/GetConfig.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/examples/GetObject.hs
+++ b/examples/GetObject.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import qualified Data.Conduit.Binary as CB
 import           Prelude
 
 -- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo

--- a/examples/HeadObject.hs
+++ b/examples/HeadObject.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import           Network.Minio.S3API
 import           Prelude
 
 -- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo

--- a/examples/Heal.hs
+++ b/examples/Heal.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/examples/ListBuckets.hs
+++ b/examples/ListBuckets.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import           Control.Monad.IO.Class (liftIO)
 import           Prelude
 
 -- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo

--- a/examples/ListIncompleteUploads.hs
+++ b/examples/ListIncompleteUploads.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import           Conduit
 import           Prelude
 
 -- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo
@@ -42,7 +42,7 @@ main = do
   print res
 
   {-
-    Following is the output of the above program on a local Minio server.
+    Following is the output of the above program on a local MinIO server.
 
     Right [UploadInfo { uiKey = "go1.6.2.linux-amd64.tar.gz"
                       , uiUploadId = "063eb592-bdd7-4a0c-be48-34fb3ceb63e2"

--- a/examples/ListObjects.hs
+++ b/examples/ListObjects.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import           Prelude
 
 
 -- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo
@@ -37,12 +37,12 @@ main = do
     bucket = "test"
 
   -- Performs a recursive listing of all objects under bucket "test"
-  -- on play.minio.io.
+  -- on play.min.io.
   res <- runMinio minioPlayCI $
     runConduit $ listObjects bucket Nothing True .| mapM_C (\v -> (liftIO $ print v))
   print res
   {-
-    Following is the output of the above program on a local Minio server.
+    Following is the output of the above program on a local MinIO server.
 
     Right [ObjectInfo {oiObject = "ADVANCED.png", oiModTime = 2017-02-10 05:33:24.816 UTC, oiETag = "\"a69f3af6bbb06fe1d42ac910ec30482f\"", oiSize = 94026},ObjectInfo {oiObject = "obj", oiModTime = 2017-02-10 08:49:26.777 UTC, oiETag = "\"715a872a253a3596652c1490081b4b6a-1\"", oiSize = 15728640}]
   -}

--- a/examples/MakeBucket.hs
+++ b/examples/MakeBucket.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import           Network.Minio
 import           Prelude
 
 -- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo

--- a/examples/PresignedGetObject.hs
+++ b/examples/PresignedGetObject.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import qualified Data.Conduit.Combinators as CC
 import qualified Data.Text.Encoding       as E
 
 -- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo

--- a/examples/PresignedPostPolicy.hs
+++ b/examples/PresignedPostPolicy.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import qualified Data.Text.Encoding    as Enc
 import qualified Data.Time             as Time
 
 -- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo

--- a/examples/PresignedPutObject.hs
+++ b/examples/PresignedPutObject.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import qualified Data.ByteString.Char8 as B
 import           Data.CaseInsensitive  (original)
 
 -- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo

--- a/examples/PutObject.hs
+++ b/examples/PutObject.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import qualified Data.Conduit.Combinators as CC
 import           Prelude
 
 -- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo

--- a/examples/RemoveBucket.hs
+++ b/examples/RemoveBucket.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import           Network.Minio
 import           Prelude
 
 -- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo

--- a/examples/RemoveIncompleteUpload.hs
+++ b/examples/RemoveIncompleteUpload.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import           Network.Minio
 import           Prelude
 
 -- | The following example uses minio's play server at
--- https://play.minio.io:9000.  The endpoint and associated
+-- https://play.min.io:9000.  The endpoint and associated
 -- credentials are provided via the libary constant,
 --
 -- > minioPlayCI :: ConnectInfo

--- a/examples/RemoveObject.hs
+++ b/examples/RemoveObject.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/examples/SelectObject.hs
+++ b/examples/SelectObject.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-13.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2019 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2019 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/examples/ServerInfo.hs
+++ b/examples/ServerInfo.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/examples/ServiceSendRestart.hs
+++ b/examples/ServiceSendRestart.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/examples/ServiceSendStop.hs
+++ b/examples/ServiceSendStop.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/examples/ServiceStatus.hs
+++ b/examples/ServiceStatus.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/examples/SetConfig.hs
+++ b/examples/SetConfig.hs
@@ -2,7 +2,7 @@
 -- stack --resolver lts-11.1 runghc --package minio-hs
 
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/minio-hs.cabal
+++ b/minio-hs.cabal
@@ -1,15 +1,15 @@
 name:                minio-hs
 version:             1.2.0
-synopsis:            A Minio Haskell Library for Amazon S3 compatible cloud
+synopsis:            A MinIO Haskell Library for Amazon S3 compatible cloud
                      storage.
-description:         The Minio Haskell client library provides simple APIs to
-                     access Minio, Amazon S3 and other API compatible cloud
+description:         The MinIO Haskell client library provides simple APIs to
+                     access MinIO, Amazon S3 and other API compatible cloud
                      storage servers.
 homepage:            https://github.com/minio/minio-hs#readme
 license:             Apache-2.0
 license-file:        LICENSE
-author:              Minio Dev Team
-maintainer:          dev@minio.io
+author:              MinIO Dev Team
+maintainer:          dev@min.io
 category:            Network, AWS, Object Storage
 build-type:          Simple
 stability:           Experimental

--- a/src/Lib/Prelude.hs
+++ b/src/Lib/Prelude.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/src/Network/Minio.hs
+++ b/src/Network/Minio.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 
 -- |
 -- Module:      Network.Minio
--- Copyright:   (c) 2017-2019 Minio Dev Team
+-- Copyright:   (c) 2017-2019 MinIO Dev Team
 -- License:     Apache 2.0
--- Maintainer:  Minio Dev Team <dev@minio.io>
+-- Maintainer:  MinIO Dev Team <dev@min.io>
 --
 -- Types and functions to access S3 compatible object storage servers
--- like Minio.
+-- like MinIO.
 
 module Network.Minio
   (
@@ -51,7 +51,7 @@ module Network.Minio
 
   -- * Minio Monad
   ----------------
-  -- | The Minio monad provides connection-reuse, bucket-location
+  -- | The Minio Monad provides connection-reuse, bucket-location
   -- caching, resource management and simpler error handling
   -- functionality. All actions on object storage are performed within
   -- this Monad.
@@ -209,7 +209,7 @@ module Network.Minio
 ) where
 
 {-
-This module exports the high-level Minio API for object storage.
+This module exports the high-level MinIO API for object storage.
 -}
 
 import qualified Data.Conduit             as C

--- a/src/Network/Minio/API.hs
+++ b/src/Network/Minio/API.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/src/Network/Minio/APICommon.hs
+++ b/src/Network/Minio/APICommon.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/src/Network/Minio/AdminAPI.hs
+++ b/src/Network/Minio/AdminAPI.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
 --
 
 module Network.Minio.AdminAPI
-  ( -- * Minio Admin API
+  ( -- * MinIO Admin API
     --------------------
-    -- | Provides Minio admin API and related types. It is in
+    -- | Provides MinIO admin API and related types. It is in
     -- experimental state.
     DriveInfo(..)
   , ErasureInfo(..)
@@ -401,7 +401,7 @@ serviceStatus = do
         Right ss -> return ss
         Left err -> throwIO $ MErrVJsonParse $ T.pack err
 
--- | Send service restart or stop action to Minio server.
+-- | Send service restart or stop action to MinIO server.
 serviceSendAction :: ServiceAction -> Minio ()
 serviceSendAction action = do
     let payload = PayloadBS $ LBS.toStrict $ A.encode action

--- a/src/Network/Minio/CopyObject.hs
+++ b/src/Network/Minio/CopyObject.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/src/Network/Minio/Data.hs
+++ b/src/Network/Minio/Data.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -93,7 +93,7 @@ awsRegionMap = Map.fromList [
 -- enable the @OverloadedStrings@ language extension and use the
 -- `IsString` instance to provide a URL, for example:
 --
--- > let c :: ConnectInfo = "https://play.minio.io:9000"
+-- > let c :: ConnectInfo = "https://play.min.io:9000"
 data ConnectInfo = ConnectInfo {
     connectHost               :: Text
   , connectPort               :: Int
@@ -211,13 +211,13 @@ awsCI :: ConnectInfo
 awsCI = "https://s3.amazonaws.com"
 
 
--- | <https://play.minio.io:9000 Minio Play Server>
+-- | <https://play.min.io:9000 MinIO Play Server>
 -- ConnectInfo. Credentials are already filled in.
 minioPlayCI :: ConnectInfo
 minioPlayCI = let playCreds = Credentials "Q3AM3UQ867SPQQA43P2F" "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
               in setCreds playCreds
                  $ setRegion "us-east-1"
-                 "https://play.minio.io:9000"
+                 "https://play.min.io:9000"
 
 -- |
 -- Represents a bucket in the object store

--- a/src/Network/Minio/Data/ByteString.hs
+++ b/src/Network/Minio/Data/ByteString.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/src/Network/Minio/Data/Crypto.hs
+++ b/src/Network/Minio/Data/Crypto.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/src/Network/Minio/Data/Time.hs
+++ b/src/Network/Minio/Data/Time.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/src/Network/Minio/Errors.hs
+++ b/src/Network/Minio/Errors.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/src/Network/Minio/JsonParser.hs
+++ b/src/Network/Minio/JsonParser.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/src/Network/Minio/ListOps.hs
+++ b/src/Network/Minio/ListOps.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/src/Network/Minio/PresignedOperations.hs
+++ b/src/Network/Minio/PresignedOperations.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/src/Network/Minio/PutObject.hs
+++ b/src/Network/Minio/PutObject.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/src/Network/Minio/S3API.hs
+++ b/src/Network/Minio/S3API.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/src/Network/Minio/SelectAPI.hs
+++ b/src/Network/Minio/SelectAPI.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017-2019 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017-2019 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ module Network.Minio.SelectAPI
   (
 
   -- | The `selectObjectContent` allows querying CSV, JSON or Parquet
-  -- format objects in AWS S3 and in Minio using SQL Select
+  -- format objects in AWS S3 and in MinIO using SQL Select
   -- statements. This allows significant reduction of data transfer
   -- from object storage for computation-intensive tasks, as relevant
   -- data is filtered close to the storage.

--- a/src/Network/Minio/Sign/V4.hs
+++ b/src/Network/Minio/Sign/V4.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/src/Network/Minio/Utils.hs
+++ b/src/Network/Minio/Utils.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/src/Network/Minio/XmlGenerator.hs
+++ b/src/Network/Minio/XmlGenerator.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/src/Network/Minio/XmlParser.hs
+++ b/src/Network/Minio/XmlParser.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/test/LiveServer.hs
+++ b/test/LiveServer.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/test/Network/Minio/API/Test.hs
+++ b/test/Network/Minio/API/Test.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ objectNameValidityTests = testGroup "Object Name Validity Tests"
   ]
 
 parseServerInfoJSONTest :: TestTree
-parseServerInfoJSONTest = testGroup "Parse Minio Admin API ServerInfo JSON test" $
+parseServerInfoJSONTest = testGroup "Parse MinIO Admin API ServerInfo JSON test" $
   map (\(tName, tDesc, tfn, tVal) -> testCase tName $ assertBool tDesc $
         tfn (eitherDecode tVal :: Either [Char] [ServerInfo])) testCases
   where
@@ -71,7 +71,7 @@ parseServerInfoJSONTest = testGroup "Parse Minio Admin API ServerInfo JSON test"
     invalidJSON = "[{\"error\":\"\",\"addr\":\"192.168.1.218:9000\",\"data\":{\"storage\":{\"Used\":83084,\"Backend\":{\"Type\":42,\"OnlineDisks\":4,\"OfflineDisks\":0,\"StandardSCData\":2,\"StandardSCParity\":2,\"RRSCData\":2,\"RRSCParity\":2,\"Sets\":[[{\"uuid\":\"16ec6f2c-9197-4787-904a-36bb2c2683f8\",\"endpoint\":\"/tmp/1\",\"state\":\"ok\"},{\"uuid\":\"4052e086-ef99-4aa5-ae2b-8e27559432f6\",\"endpoint\":\"/tmp/2\",\"state\":\"ok\"},{\"uuid\":\"d0639950-ddd3-45b0-93ca-fd86f5d79f72\",\"endpoint\":\"/tmp/3\",\"state\":\"ok\"},{\"uuid\":\"30ec68c0-37e1-4592-82c1-26b143c0ac10\",\"endpoint\":\"/tmp/4\",\"state\":\"ok\"}]]}},\"network\":{\"transferred\":404,\"received\":0},\"http\":{\"totalHEADs\":{\"count\":0,\"avgDuration\":\"0s\"},\"successHEADs\":{\"count\":0,\"avgDuration\":\"0s\"},\"totalGETs\":{\"count\":0,\"avgDuration\":\"0s\"},\"successGETs\":{\"count\":0,\"avgDuration\":\"0s\"},\"totalPUTs\":{\"count\":0,\"avgDuration\":\"0s\"},\"successPUTs\":{\"count\":0,\"avgDuration\":\"0s\"},\"totalPOSTs\":{\"count\":0,\"avgDuration\":\"0s\"},\"successPOSTs\":{\"count\":0,\"avgDuration\":\"0s\"},\"totalDELETEs\":{\"count\":0,\"avgDuration\":\"0s\"},\"successDELETEs\":{\"count\":0,\"avgDuration\":\"0s\"}},\"server\":{\"uptime\":2738903073,\"version\":\"DEVELOPMENT.GOGET\",\"commitID\":\"DEVELOPMENT.GOGET\",\"region\":\"\",\"sqsARN\":[]}}}]"
 
 parseHealStatusTest :: TestTree
-parseHealStatusTest = testGroup "Parse Minio Admin API HealStatus JSON test" $
+parseHealStatusTest = testGroup "Parse MinIO Admin API HealStatus JSON test" $
   map (\(tName, tDesc, tfn, tVal) -> testCase tName $ assertBool tDesc $
         tfn (eitherDecode tVal :: Either [Char] HealStatus)) testCases
 
@@ -88,7 +88,7 @@ parseHealStatusTest = testGroup "Parse Minio Admin API HealStatus JSON test" $
     invalidItemType = "{\"Summary\":\"finished\",\"StartTime\":\"2018-06-05T08:09:47.644465513Z\",\"NumDisks\":4,\"Settings\":{\"recursive\":false,\"dryRun\":false},\"Items\":[{\"resultId\":1,\"type\":\"hello\",\"bucket\":\"\",\"object\":\"\",\"detail\":\"disk-format\",\"diskCount\":4,\"setCount\":1,\"before\":{\"drives\":[{\"uuid\":\"c3487166-b8a4-481a-b1e7-fb9b249e2500\",\"endpoint\":\"/tmp/1\",\"state\":\"ok\"},{\"uuid\":\"55a6e787-184f-4e4c-bf09-03dcada658a9\",\"endpoint\":\"/tmp/2\",\"state\":\"ok\"},{\"uuid\":\"f035d8c3-fca1-4407-b89c-38c2bcf4a641\",\"endpoint\":\"/tmp/3\",\"state\":\"ok\"},{\"uuid\":\"4f8b79d3-db90-4c1d-87c2-35a28b0d9a13\",\"endpoint\":\"/tmp/4\",\"state\":\"ok\"}]},\"after\":{\"drives\":[{\"uuid\":\"c3487166-b8a4-481a-b1e7-fb9b249e2500\",\"endpoint\":\"/tmp/1\",\"state\":\"ok\"},{\"uuid\":\"55a6e787-184f-4e4c-bf09-03dcada658a9\",\"endpoint\":\"/tmp/2\",\"state\":\"ok\"},{\"uuid\":\"f035d8c3-fca1-4407-b89c-38c2bcf4a641\",\"endpoint\":\"/tmp/3\",\"state\":\"ok\"},{\"uuid\":\"4f8b79d3-db90-4c1d-87c2-35a28b0d9a13\",\"endpoint\":\"/tmp/4\",\"state\":\"ok\"}]},\"objectSize\":0}]}"
 
 parseHealStartRespTest :: TestTree
-parseHealStartRespTest = testGroup "Parse Minio Admin API HealStartResp JSON test" $
+parseHealStartRespTest = testGroup "Parse MinIO Admin API HealStartResp JSON test" $
   map (\(tName, tDesc, tfn, tVal) -> testCase tName $ assertBool tDesc $
         tfn (eitherDecode tVal :: Either [Char] HealStartResp)) testCases
 

--- a/test/Network/Minio/JsonParser/Test.hs
+++ b/test/Network/Minio/JsonParser/Test.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/test/Network/Minio/TestHelpers.hs
+++ b/test/Network/Minio/TestHelpers.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/test/Network/Minio/Utils/Test.hs
+++ b/test/Network/Minio/Utils/Test.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/test/Network/Minio/XmlGenerator/Test.hs
+++ b/test/Network/Minio/XmlGenerator/Test.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/test/Network/Minio/XmlParser/Test.hs
+++ b/test/Network/Minio/XmlParser/Test.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,5 +1,5 @@
 --
--- Minio Haskell SDK, (C) 2017, 2018 Minio, Inc.
+-- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes #113 

Official company name `Minio` became `MinIO`. 
This change required our documentation and codebase to be modified for all references to the old name, `Minio`, as `MinIO` and the links `....://xxx.minio.io` as `....://xxx.min.io`.

## Description of the change
The changes are in `../docs/*` and code files.

Used Visual Studio Code Editor regular expressions to find and replace those patterns that match the desired text. Here are several regular expressions used to complete the job in 2 steps:

1. Choose `Match Case` and `Use Regular Expression` and replace the links using the following regular expressions:

| Find | Replace |
| ------ | ----------- |
|minio\.io | min.io |

2. 
| Find | Replace |
| ------ | ----------- |
| [^\.]\bMinio\b(?! \(\| \[\| Monad) | MinIO |
| (".*)\bMinio\b(.*") | $1MinIO$2 |
| ^--(.*[^\.])\bMinio\b(?! Monad\| action) | --$1MinIO |