### PR TITLE
Add simple TLS helpers:

### DIFF
--- a/examples/BucketExists.hs
+++ b/examples/BucketExists.hs
@@ -17,11 +17,11 @@
 -- limitations under the License.
 --
 
-{-# Language OverloadedStrings #-}
-import Network.Minio
+{-# LANGUAGE OverloadedStrings #-}
+import           Network.Minio
 
-import Control.Monad.IO.Class (liftIO)
-import Prelude
+import           Control.Monad.IO.Class (liftIO)
+import           Prelude
 
 -- | The following example uses minio's play server at
 -- https://play.min.io:9000.  The endpoint and associated
@@ -39,5 +39,5 @@ main = do
     liftIO $ putStrLn $ "Does " ++ show bucket ++ " exist? - " ++ show foundBucket
 
   case res1 of
-    Left e -> putStrLn $ "bucketExists failed." ++ show e
+    Left e   -> putStrLn $ "bucketExists failed." ++ show e
     Right () -> return ()

--- a/minio-hs.cabal
+++ b/minio-hs.cabal
@@ -56,6 +56,7 @@ library
                      , case-insensitive >= 1.2
                      , conduit >= 1.3
                      , conduit-extra >= 1.3
+                     , connection
                      , containers >= 0.5
                      , cryptonite >= 0.25
                      , cryptonite-conduit >= 0.2
@@ -64,6 +65,7 @@ library
                      , exceptions
                      , filepath >= 1.4
                      , http-client >= 0.5
+                     , http-client-tls
                      , http-conduit >= 2.3
                      , http-types >= 0.12
                      , ini
@@ -142,6 +144,7 @@ test-suite minio-hs-live-server-test
   build-depends:       base >= 4.7 && < 5
                      , minio-hs
                      , protolude >= 0.1.6
+                     , QuickCheck
                      , aeson
                      , base64-bytestring
                      , binary
@@ -149,6 +152,7 @@ test-suite minio-hs-live-server-test
                      , case-insensitive
                      , conduit
                      , conduit-extra
+                     , connection
                      , containers
                      , cryptonite
                      , cryptonite-conduit
@@ -157,11 +161,11 @@ test-suite minio-hs-live-server-test
                      , exceptions
                      , filepath
                      , http-client
+                     , http-client-tls
                      , http-conduit
                      , http-types
                      , ini
                      , memory
-                     , QuickCheck
                      , raw-strings-qq >= 1
                      , resourcet
                      , retry
@@ -187,6 +191,7 @@ test-suite minio-hs-test
   build-depends:       base >= 4.7 && < 5
                      , minio-hs
                      , protolude >= 0.1.6
+                     , QuickCheck
                      , aeson
                      , base64-bytestring
                      , binary
@@ -194,19 +199,20 @@ test-suite minio-hs-test
                      , case-insensitive
                      , conduit
                      , conduit-extra
+                     , connection
                      , containers
                      , cryptonite
                      , cryptonite-conduit
-                     , filepath
                      , digest
                      , directory
                      , exceptions
+                     , filepath
                      , http-client
+                     , http-client-tls
                      , http-conduit
                      , http-types
                      , ini
                      , memory
-                     , QuickCheck
                      , raw-strings-qq >= 1
                      , resourcet
                      , retry

--- a/src/Network/Minio.hs
+++ b/src/Network/Minio.hs
@@ -39,6 +39,8 @@ module Network.Minio
   , setRegion
   , setCreds
   , setCredsFrom
+  , isConnectInfoSecure
+  , disableTLSCertValidation
   , MinioConn
   , mkMinioConn
 


### PR DESCRIPTION
- Check if ConnectInfo is secure

- Option to disable TLS certificate validation (to make testing
  easier).