### PR TITLE
Add streaming signature for PutObject

### DIFF
--- a/minio-hs.cabal
+++ b/minio-hs.cabal
@@ -116,15 +116,18 @@ test-suite minio-hs-live-server-test
                      , TypeFamilies
   other-modules:       Lib.Prelude
                      , Network.Minio
-                     , Network.Minio.AdminAPI
                      , Network.Minio.API
+                     , Network.Minio.API.Test
                      , Network.Minio.APICommon
+                     , Network.Minio.AdminAPI
                      , Network.Minio.CopyObject
                      , Network.Minio.Data
                      , Network.Minio.Data.ByteString
                      , Network.Minio.Data.Crypto
                      , Network.Minio.Data.Time
                      , Network.Minio.Errors
+                     , Network.Minio.JsonParser
+                     , Network.Minio.JsonParser.Test
                      , Network.Minio.ListOps
                      , Network.Minio.PresignedOperations
                      , Network.Minio.PutObject
@@ -134,13 +137,10 @@ test-suite minio-hs-live-server-test
                      , Network.Minio.TestHelpers
                      , Network.Minio.Utils
                      , Network.Minio.Utils.Test
-                     , Network.Minio.API.Test
                      , Network.Minio.XmlGenerator
                      , Network.Minio.XmlGenerator.Test
                      , Network.Minio.XmlParser
                      , Network.Minio.XmlParser.Test
-                     , Network.Minio.JsonParser
-                     , Network.Minio.JsonParser.Test
   build-depends:       base >= 4.7 && < 5
                      , minio-hs
                      , protolude >= 0.1.6
@@ -243,15 +243,18 @@ test-suite minio-hs-test
                      , TypeFamilies
   other-modules:       Lib.Prelude
                      , Network.Minio
-                     , Network.Minio.AdminAPI
                      , Network.Minio.API
+                     , Network.Minio.API.Test
                      , Network.Minio.APICommon
+                     , Network.Minio.AdminAPI
+                     , Network.Minio.CopyObject
                      , Network.Minio.Data
                      , Network.Minio.Data.ByteString
                      , Network.Minio.Data.Crypto
                      , Network.Minio.Data.Time
-                     , Network.Minio.CopyObject
                      , Network.Minio.Errors
+                     , Network.Minio.JsonParser
+                     , Network.Minio.JsonParser.Test
                      , Network.Minio.ListOps
                      , Network.Minio.PresignedOperations
                      , Network.Minio.PutObject
@@ -261,13 +264,10 @@ test-suite minio-hs-test
                      , Network.Minio.TestHelpers
                      , Network.Minio.Utils
                      , Network.Minio.Utils.Test
-                     , Network.Minio.API.Test
                      , Network.Minio.XmlGenerator
                      , Network.Minio.XmlGenerator.Test
                      , Network.Minio.XmlParser
                      , Network.Minio.XmlParser.Test
-                     , Network.Minio.JsonParser
-                     , Network.Minio.JsonParser.Test
 
 source-repository head
   type:     git

--- a/src/Network/Minio/Data.hs
+++ b/src/Network/Minio/Data.hs
@@ -20,6 +20,7 @@
 {-# LANGUAGE TypeFamilies               #-}
 module Network.Minio.Data where
 
+import qualified Conduit                      as C
 import           Control.Concurrent.MVar      (MVar)
 import qualified Control.Concurrent.MVar      as M
 import           Control.Monad.IO.Unlift      (MonadUnliftIO, UnliftIO (..),
@@ -883,10 +884,10 @@ type Stats = Progress
 
 -- | Represents different kinds of payload that are used with S3 API
 -- requests.
-data Payload = PayloadBS ByteString
-             | PayloadH Handle
-                        Int64 -- offset
-                        Int64 -- size
+data Payload
+    = PayloadBS ByteString
+    | PayloadH Handle Int64 Int64 -- file handle, offset and length
+    | PayloadC Int64 (C.ConduitT () ByteString (ResourceT IO) ()) -- length and byte source
 
 defaultPayload :: Payload
 defaultPayload = PayloadBS ""

--- a/src/Network/Minio/Errors.hs
+++ b/src/Network/Minio/Errors.hs
@@ -1,5 +1,5 @@
 --
--- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
+-- MinIO Haskell SDK, (C) 2017-2019 MinIO, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -42,6 +42,8 @@ data MErrV = MErrVSinglePUTSizeExceeded Int64
            | MErrVInvalidHealPath
            | MErrVMissingCredentials
            | MErrVInvalidEncryptionKeyLength
+           | MErrVStreamingBodyUnexpectedEOF
+           | MErrVUnexpectedPayload
   deriving (Show, Eq)
 
 instance Exception MErrV


### PR DESCRIPTION
Use streaming signature to avoid reading the body twice in PutObject
requests, where the body can be upto 5GIB.

Note that the body is signed only used when the connection is not
using TLS.