### PR TITLE
correct us-west-2 region reference in minio data module

### DIFF
--- a/src/Network/Minio/Data.hs
+++ b/src/Network/Minio/Data.hs
@@ -77,7 +77,7 @@ awsRegionMap = H.fromList [
       ("us-east-1", "s3.amazonaws.com")
     , ("us-east-2", "s3-us-east-2.amazonaws.com")
     , ("us-west-1", "s3-us-west-1.amazonaws.com")
-    , ("us-east-2", "s3-us-west-2.amazonaws.com")
+    , ("us-west-2", "s3-us-west-2.amazonaws.com")
     , ("ca-central-1", "s3-ca-central-1.amazonaws.com")
     , ("ap-south-1", "s3-ap-south-1.amazonaws.com")
     , ("ap-northeast-1", "s3-ap-northeast-1.amazonaws.com")


### PR DESCRIPTION
I noticed that us-west-2 wasn't working for me, which then lead me to find that us-west-2 wasn't included in the `Data` module.