### PR TITLE
New release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,9 +53,9 @@ install:
 script:
   - |
     if [ -z "$STACK_YAML" ]; then
-      MINIO_LOCAL=1 MINIO_SECURE=1 cabal new-test --enable-tests
+      MINIO_LOCAL=1 MINIO_SECURE=1 cabal new-test --enable-tests -flive-test
     else
-      MINIO_LOCAL=1 MINIO_SECURE=1 stack test --system-ghc
+      MINIO_LOCAL=1 MINIO_SECURE=1 stack test --system-ghc --flag minio-hs:live-test
     fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
   include:
 
   # Cabal
-  - ghc: 8.2.2
   - ghc: 8.4.4
   - ghc: 8.6.5
   - ghc: 8.8.1
@@ -40,14 +39,14 @@ install:
       ghc --version
       cabal --version
       cabal new-update
-      cabal new-build --enable-tests --enable-benchmarks
+      cabal new-build --enable-tests --enable-benchmarks -fexamples
     else
       # install stack
       curl -sSL https://get.haskellstack.org/ | sh
 
       # build project with stack
       stack --version
-      stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks
+      stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks --flag minio-hs:examples
     fi
 
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 ==========
 
+## Version 1.5.2
+
+* Fix region `us-west-2` for AWS S3 (#139)
+* Build examples in CI
+* Disable live-server tests by default, but run them in CI
+* Drop support for GHC 8.2.x
+
 ## Version 1.5.1
 
 * Add support for GHC 8.8

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ The MinIO Haskell Client SDK provides simple APIs to access [MinIO](https://min.
 
 ### Add to your project
 
-Simply add `minio-hs` to your project's `.cabal` dependencies section or if you
-are using hpack, to your `package.yaml` file as usual.
+Simply add `minio-hs` to your project's `.cabal` dependencies section or if you are using hpack, to your `package.yaml` file as usual.
 
 ### Try it out directly with `ghci`
 
@@ -31,11 +30,15 @@ $ stack ghci
 > :browse Network.Minio
 ```
 
-## Quick-Start Example - File Uploader
+## Examples
+
+The [examples](https://github.com/minio/minio-hs/tree/master/examples) folder contains many examples that you can try out and use to learn and to help with developing your own projects.
+
+### Quick-Start Example - File Uploader
 
 This example program connects to a MinIO object storage server, makes a bucket on the server and then uploads a file to the bucket.
 
-We will use the MinIO server running at https://play.min.io in this example. Feel free to use this service for testing and development. Access credentials shown in this example are open to the public.
+We will use the MinIO server running at https://play.min.io in this example. Feel free to use this service for testing and development. Access credentials are present in the library and are open to the public.
 
 ### FileUploader.hs
 ``` haskell
@@ -149,12 +152,7 @@ stack test
 
 ```
 
-A section of the tests use the remote MinIO Play server at
-`https://play.min.io` by default. For library development,
-using this remote server maybe slow. To run the tests against a
-locally running MinIO live server at `http://localhost:9000`, just set
-the environment `MINIO_LOCAL` to any value (and unset it to switch
-back to Play).
+A section of the tests use the remote MinIO Play server at `https://play.min.io` by default. For library development, using this remote server maybe slow. To run the tests against a locally running MinIO live server at `http://localhost:9000`, just set the environment `MINIO_LOCAL` to any value (and unset it to switch back to Play).
 
 To run the live server tests, set a build flag as shown below:
 

--- a/examples/BucketExists.hs
+++ b/examples/BucketExists.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.

--- a/examples/FileUploader.hs
+++ b/examples/FileUploader.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs --package optparse-applicative --package filepath
+-- stack --resolver lts-14.11 runghc --package minio-hs --package optparse-applicative --package filepath
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
@@ -43,6 +43,7 @@ fileNameArgs = strArgument
                (metavar "FILENAME"
                 <> help "Name of file to upload to AWS S3 or a MinIO server")
 
+cmdParser :: ParserInfo FilePath
 cmdParser = info
             (helper <*> fileNameArgs)
             (fullDesc
@@ -62,12 +63,12 @@ main = do
     -- Make a bucket; catch bucket already exists exception if thrown.
     bErr <- try $ makeBucket bucket Nothing
     case bErr of
-      Left (MErrService BucketAlreadyOwnedByYou) -> return ()
-      Left e                                     -> throwIO e
-      Right _                                    -> return ()
+      Left BucketAlreadyOwnedByYou -> return ()
+      Left e                       -> throwIO e
+      Right _                      -> return ()
 
     -- Upload filepath to bucket; object is derived from filepath.
-    fPutObject bucket object filepath def
+    fPutObject bucket object filepath defaultPutObjectOptions
 
   case res of
     Left e   -> putStrLn $ "file upload failed due to " ++ (show e)

--- a/examples/GetConfig.hs
+++ b/examples/GetConfig.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
@@ -25,6 +25,6 @@ import           Prelude
 
 main :: IO ()
 main = do
-  res <- runMinio def $
+  res <- runMinio minioPlayCI $
       getConfig
   print res

--- a/examples/GetObject.hs
+++ b/examples/GetObject.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
@@ -38,8 +38,8 @@ main = do
       bucket = "my-bucket"
       object = "my-object"
   res <- runMinio minioPlayCI $ do
-    src <- getObject bucket object def
-    C.connect src $ CB.sinkFileCautious "/tmp/my-object"
+    src <- getObject bucket object defaultGetObjectOptions
+    C.connect (gorObjectStream src) $ CB.sinkFileCautious "/tmp/my-object"
 
   case res of
     Left e  -> putStrLn $ "getObject failed." ++ (show e)

--- a/examples/HeadObject.hs
+++ b/examples/HeadObject.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
@@ -36,7 +36,7 @@ main = do
       bucket = "test"
       object = "passwd"
   res <- runMinio minioPlayCI $
-    headObject bucket object
+    headObject bucket object []
 
   case res of
     Left e        -> putStrLn $ "headObject failed." ++ show e

--- a/examples/Heal.hs
+++ b/examples/Heal.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
@@ -25,7 +25,7 @@ import           Prelude
 
 main :: IO ()
 main = do
-  res <- runMinio def $
+  res <- runMinio minioPlayCI $
     do
       hsr <- startHeal Nothing Nothing HealOpts { hoRecursive = True
                                                 , hoDryRun = False

--- a/examples/ListBuckets.hs
+++ b/examples/ListBuckets.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.

--- a/examples/ListIncompleteUploads.hs
+++ b/examples/ListIncompleteUploads.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.

--- a/examples/ListObjects.hs
+++ b/examples/ListObjects.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.

--- a/examples/MakeBucket.hs
+++ b/examples/MakeBucket.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.

--- a/examples/PresignedGetObject.hs
+++ b/examples/PresignedGetObject.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
@@ -47,11 +47,11 @@ main = do
 
   res <- runMinio minioPlayCI $ do
     liftIO $ B.putStrLn "Upload a file that we will fetch with a presigned URL..."
-    putObject bucket object (CC.repeat "a") (Just kb15) def
+    putObject bucket object (CC.repeat "a") (Just kb15) defaultPutObjectOptions
     liftIO $ putStrLn $ "Done. Object created at: my-bucket/my-object"
 
     -- Extract Etag of uploaded object
-    oi <- statObject bucket object
+    oi <- statObject bucket object defaultGetObjectOptions
     let etag = oiETag oi
 
     -- Set header to add an if-match constraint - this makes sure
@@ -68,7 +68,7 @@ main = do
 
   case res of
     Left e -> putStrLn $ "presignedPutObject URL failed." ++ show e
-    Right (headers, etag, url) -> do
+    Right (headers, _, url) -> do
 
       -- We generate a curl command to demonstrate usage of the signed
       -- URL.

--- a/examples/PresignedPostPolicy.hs
+++ b/examples/PresignedPostPolicy.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
@@ -38,7 +38,7 @@ main = do
   now <- Time.getCurrentTime
   let
     bucket = "my-bucket"
-    object = "my-object"
+    object = "photos/my-object"
 
     -- set an expiration time of 10 days
     expireTime = Time.addUTCTime (3600 * 24 * 10) now
@@ -47,9 +47,9 @@ main = do
     -- conditions are validated, newPostPolicy returns an Either value
     policyE = newPostPolicy expireTime
               [ -- set the object name condition
-                ppCondKey "photos/my-object"
+                ppCondKey object
                 -- set the bucket name condition
-              , ppCondBucket "my-bucket"
+              , ppCondBucket bucket
                 -- set the size range of object as 1B to 10MiB
               , ppCondContentLengthRange 1 (10*1024*1024)
                 -- set content type as jpg image

--- a/examples/PresignedPutObject.hs
+++ b/examples/PresignedPutObject.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.

--- a/examples/PutObject.hs
+++ b/examples/PutObject.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
@@ -41,14 +41,14 @@ main = do
 
   -- Eg 1. Upload a stream of repeating "a" using putObject with default options.
   res1 <- runMinio minioPlayCI $
-    putObject bucket object (CC.repeat "a") (Just kb15) def
+    putObject bucket object (CC.repeat "a") (Just kb15) defaultPutObjectOptions
   case res1 of
     Left e   -> putStrLn $ "putObject failed." ++ show e
     Right () -> putStrLn "putObject succeeded."
 
   -- Eg 2. Upload a file using fPutObject with default options.
   res2 <- runMinio minioPlayCI $
-    fPutObject bucket object localFile def
+    fPutObject bucket object localFile defaultPutObjectOptions
   case res2 of
     Left e   -> putStrLn $ "fPutObject failed." ++ show e
     Right () -> putStrLn "fPutObject succeeded."

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,17 @@
+# Examples
+
+The examples in this directory illustrate usage of various APIs provided by this library. Each file is self-contained and can be run like a script directly.
+
+To build the examples, the build flag `examples` needs to be turned on:
+
+```sh
+stack build --flag minio-hs:examples
+```
+
+Now to run and example script [BucketExists.hs](https://github.com/minio/minio-hs/blob/master/examples/BucketExists.hs):
+
+```sh
+stack exec BucketExists
+```
+
+The CI system is configured to build these examples with every change, so they should be current.

--- a/examples/RemoveBucket.hs
+++ b/examples/RemoveBucket.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.

--- a/examples/RemoveIncompleteUpload.hs
+++ b/examples/RemoveIncompleteUpload.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.

--- a/examples/RemoveObject.hs
+++ b/examples/RemoveObject.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.

--- a/examples/SelectObject.hs
+++ b/examples/SelectObject.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-13.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2019 MinIO, Inc.
@@ -22,7 +22,6 @@ import           Network.Minio
 
 import qualified Conduit              as C
 import           Control.Monad        (when)
-import qualified Data.ByteString.Lazy as LB
 
 import           Prelude
 

--- a/examples/ServerInfo.hs
+++ b/examples/ServerInfo.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
@@ -25,6 +25,6 @@ import           Prelude
 
 main :: IO ()
 main = do
-  res <- runMinio def $
+  res <- runMinio minioPlayCI $
     getServerInfo
   print res

--- a/examples/ServiceSendRestart.hs
+++ b/examples/ServiceSendRestart.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
@@ -25,6 +25,6 @@ import           Prelude
 
 main :: IO ()
 main = do
-  res <- runMinio def $
+  res <- runMinio minioPlayCI $
     serviceSendAction ServiceActionRestart
   print res

--- a/examples/ServiceSendStop.hs
+++ b/examples/ServiceSendStop.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
@@ -25,6 +25,6 @@ import           Prelude
 
 main :: IO ()
 main = do
-  res <- runMinio def $
+  res <- runMinio minioPlayCI $
     serviceSendAction ServiceActionStop
   print res

--- a/examples/ServiceStatus.hs
+++ b/examples/ServiceStatus.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
@@ -25,6 +25,6 @@ import           Prelude
 
 main :: IO ()
 main = do
-  res <- runMinio def $
+  res <- runMinio minioPlayCI $
     serviceStatus
   print res

--- a/examples/SetConfig.hs
+++ b/examples/SetConfig.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-11.1 runghc --package minio-hs
+-- stack --resolver lts-14.11 runghc --package minio-hs
 
 --
 -- MinIO Haskell SDK, (C) 2017, 2018 MinIO, Inc.
@@ -25,7 +25,7 @@ import           Prelude
 
 main :: IO ()
 main = do
-  res <- runMinio def $
+  res <- runMinio minioPlayCI $
     do
       let config = "{\"version\":\"25\",\"credential\":{\"accessKey\":\"minio\",\"secretKey\":\"minio123\"},\"region\":\"\",\"browser\":\"on\",\"worm\":\"off\",\"domain\":\"\",\"storageclass\":{\"standard\":\"\",\"rrs\":\"\"},\"cache\":{\"drives\":[],\"expiry\":90,\"exclude\":[]},\"notify\":{\"amqp\":{\"2\":{\"enable\":false,\"url\":\"amqp://guest:guest@localhost:5672/\",\"exchange\":\"minio\",\"routingKey\":\"minio\",\"exchangeType\":\"direct\",\"deliveryMode\":0,\"mandatory\":false,\"immediate\":false,\"durable\":false,\"internal\":false,\"noWait\":false,\"autoDeleted\":false}},\"elasticsearch\":{\"1\":{\"enable\":false,\"format\":\"namespace\",\"url\":\"http://localhost:9200\",\"index\":\"minio_events\"}},\"kafka\":{\"1\":{\"enable\":false,\"brokers\":null,\"topic\":\"\"}},\"mqtt\":{\"1\":{\"enable\":false,\"broker\":\"\",\"topic\":\"\",\"qos\":0,\"clientId\":\"\",\"username\":\"\",\"password\":\"\",\"reconnectInterval\":0,\"keepAliveInterval\":0}},\"mysql\":{\"1\":{\"enable\":false,\"format\":\"namespace\",\"dsnString\":\"\",\"table\":\"\",\"host\":\"\",\"port\":\"\",\"user\":\"\",\"password\":\"\",\"database\":\"\"}},\"nats\":{\"1\":{\"enable\":false,\"address\":\"\",\"subject\":\"\",\"username\":\"\",\"password\":\"\",\"token\":\"\",\"secure\":false,\"pingInterval\":0,\"streaming\":{\"enable\":false,\"clusterID\":\"\",\"clientID\":\"\",\"async\":false,\"maxPubAcksInflight\":0}}},\"postgresql\":{\"1\":{\"enable\":false,\"format\":\"namespace\",\"connectionString\":\"\",\"table\":\"\",\"host\":\"\",\"port\":\"\",\"user\":\"\",\"password\":\"\",\"database\":\"\"}},\"redis\":{\"test1\":{\"enable\":true,\"format\":\"namespace\",\"address\":\"127.0.0.1:6379\",\"password\":\"\",\"key\":\"bucketevents_ns\"},\"test2\":{\"enable\":true,\"format\":\"access\",\"address\":\"127.0.0.1:6379\",\"password\":\"\",\"key\":\"bucketevents_log\"}},\"webhook\":{\"1\":{\"enable\":true,\"endpoint\":\"http://localhost:3000\"},\"2\":{\"enable\":true,\"endpoint\":\"http://localhost:3001\"}}}}"
       setConfig config

--- a/minio-hs.cabal
+++ b/minio-hs.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                minio-hs
-version:             1.5.1
+version:             1.5.2
 synopsis:            A MinIO Haskell Library for Amazon S3 compatible cloud
                      storage.
 description:         The MinIO Haskell client library provides simple APIs to

--- a/minio-hs.cabal
+++ b/minio-hs.cabal
@@ -1,3 +1,4 @@
+cabal-version:       2.2
 name:                minio-hs
 version:             1.5.1
 synopsis:            A MinIO Haskell Library for Amazon S3 compatible cloud
@@ -21,14 +22,21 @@ extra-source-files:
                    README.md
                    stack.yaml
 
-cabal-version:       >=1.10
 
-library
-  hs-source-dirs:      src
+common base-settings
   ghc-options:         -Wall
-  exposed-modules:     Network.Minio
-                     , Network.Minio.AdminAPI
-                     , Network.Minio.S3API
+  default-language:    Haskell2010
+  default-extensions:  BangPatterns
+                     , FlexibleContexts
+                     , FlexibleInstances
+                     , MultiParamTypeClasses
+                     , MultiWayIf
+                     , NoImplicitPrelude
+                     , OverloadedStrings
+                     , RankNTypes
+                     , ScopedTypeVariables
+                     , TypeFamilies
+                     , TupleSections
   other-modules:       Lib.Prelude
                      , Network.Minio.API
                      , Network.Minio.APICommon
@@ -79,192 +87,210 @@ library
                      , unliftio-core >= 0.1
                      , unordered-containers >= 0.2
                      , xml-conduit >= 1.8
-  default-language:    Haskell2010
-  default-extensions:  BangPatterns
-                     , FlexibleContexts
-                     , FlexibleInstances
-                     , MultiParamTypeClasses
-                     , MultiWayIf
-                     , NoImplicitPrelude
-                     , OverloadedStrings
-                     , RankNTypes
-                     , ScopedTypeVariables
-                     , TypeFamilies
-                     , TupleSections
+
+library
+  import:              base-settings
+  hs-source-dirs:      src
+  exposed-modules:     Network.Minio
+                     , Network.Minio.AdminAPI
+                     , Network.Minio.S3API
 
 Flag live-test
+  Description: Build the test suite that runs against a live MinIO server
   Default: False
   Manual: True
 
 test-suite minio-hs-live-server-test
+  import:              base-settings
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test, src
   main-is:             LiveServer.hs
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
-  default-language:    Haskell2010
-  default-extensions:  BangPatterns
-                     , FlexibleContexts
-                     , FlexibleInstances
-                     , MultiParamTypeClasses
-                     , MultiWayIf
-                     , NoImplicitPrelude
-                     , OverloadedStrings
-                     , RankNTypes
-                     , ScopedTypeVariables
-                     , TupleSections
-                     , TypeFamilies
-  other-modules:       Lib.Prelude
-                     , Network.Minio
-                     , Network.Minio.API
-                     , Network.Minio.API.Test
-                     , Network.Minio.APICommon
-                     , Network.Minio.AdminAPI
-                     , Network.Minio.CopyObject
-                     , Network.Minio.Data
-                     , Network.Minio.Data.ByteString
-                     , Network.Minio.Data.Crypto
-                     , Network.Minio.Data.Time
-                     , Network.Minio.Errors
-                     , Network.Minio.JsonParser
-                     , Network.Minio.JsonParser.Test
-                     , Network.Minio.ListOps
-                     , Network.Minio.PresignedOperations
-                     , Network.Minio.PutObject
+  other-modules:       Network.Minio
                      , Network.Minio.S3API
-                     , Network.Minio.SelectAPI
-                     , Network.Minio.Sign.V4
+                     , Network.Minio.AdminAPI
+                     , Network.Minio.API.Test
+                     , Network.Minio.JsonParser.Test
                      , Network.Minio.TestHelpers
-                     , Network.Minio.Utils
                      , Network.Minio.Utils.Test
-                     , Network.Minio.XmlGenerator
                      , Network.Minio.XmlGenerator.Test
-                     , Network.Minio.XmlParser
                      , Network.Minio.XmlParser.Test
-  build-depends:       base >= 4.7 && < 5
-                     , minio-hs
-                     , protolude >= 0.1.6
-                     , QuickCheck
-                     , aeson
-                     , base64-bytestring
-                     , binary
-                     , bytestring
-                     , case-insensitive
-                     , conduit
-                     , conduit-extra
-                     , connection
-                     , cryptonite
-                     , cryptonite-conduit
-                     , digest
-                     , directory
-                     , exceptions
-                     , filepath
-                     , http-client
-                     , http-client-tls
-                     , http-conduit
-                     , http-types
-                     , ini
-                     , memory
-                     , raw-strings-qq >= 1
-                     , resourcet
-                     , retry
+  build-depends:       minio-hs
                      , tasty
                      , tasty-hunit
                      , tasty-quickcheck
                      , tasty-smallcheck
-                     , temporary
-                     , text
-                     , time
-                     , transformers
-                     , unliftio
-                     , unliftio-core
-                     , unordered-containers
-                     , xml-conduit
+                     , QuickCheck
   if !flag(live-test)
     buildable: False
 
 test-suite minio-hs-test
+  import:              base-settings
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test, src
   main-is:             Spec.hs
-  build-depends:       base >= 4.7 && < 5
-                     , minio-hs
-                     , protolude >= 0.1.6
+  build-depends:       minio-hs
                      , QuickCheck
-                     , aeson
-                     , base64-bytestring
-                     , binary
-                     , bytestring
-                     , case-insensitive
-                     , conduit
-                     , conduit-extra
-                     , connection
-                     , cryptonite
-                     , cryptonite-conduit
-                     , digest
-                     , directory
-                     , exceptions
-                     , filepath
-                     , http-client
-                     , http-client-tls
-                     , http-conduit
-                     , http-types
-                     , ini
-                     , memory
-                     , raw-strings-qq >= 1
-                     , resourcet
-                     , retry
                      , tasty
                      , tasty-hunit
                      , tasty-quickcheck
                      , tasty-smallcheck
-                     , temporary
-                     , text
-                     , time
-                     , transformers
-                     , unliftio
-                     , unliftio-core
-                     , unordered-containers
-                     , xml-conduit
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
-  default-language:    Haskell2010
-  default-extensions:  BangPatterns
-                     , FlexibleContexts
-                     , FlexibleInstances
-                     , MultiParamTypeClasses
-                     , MultiWayIf
-                     , NoImplicitPrelude
-                     , OverloadedStrings
-                     , RankNTypes
-                     , ScopedTypeVariables
-                     , TupleSections
-                     , TypeFamilies
   other-modules:       Lib.Prelude
                      , Network.Minio
-                     , Network.Minio.API
-                     , Network.Minio.API.Test
-                     , Network.Minio.APICommon
-                     , Network.Minio.AdminAPI
-                     , Network.Minio.CopyObject
-                     , Network.Minio.Data
-                     , Network.Minio.Data.ByteString
-                     , Network.Minio.Data.Crypto
-                     , Network.Minio.Data.Time
-                     , Network.Minio.Errors
-                     , Network.Minio.JsonParser
-                     , Network.Minio.JsonParser.Test
-                     , Network.Minio.ListOps
-                     , Network.Minio.PresignedOperations
-                     , Network.Minio.PutObject
                      , Network.Minio.S3API
-                     , Network.Minio.SelectAPI
-                     , Network.Minio.Sign.V4
+                     , Network.Minio.AdminAPI
                      , Network.Minio.TestHelpers
-                     , Network.Minio.Utils
+                     , Network.Minio.API.Test
+                     , Network.Minio.JsonParser.Test
                      , Network.Minio.Utils.Test
-                     , Network.Minio.XmlGenerator
                      , Network.Minio.XmlGenerator.Test
-                     , Network.Minio.XmlParser
                      , Network.Minio.XmlParser.Test
+
+Flag examples
+  Description: Build the examples
+  Default: False
+  Manual: True
+
+common examples-settings
+  ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
+  default-language:    Haskell2010
+  default-extensions:  OverloadedStrings
+  build-depends:       base >= 4.7 && < 5
+                     , bytestring
+                     , case-insensitive
+                     , conduit
+                     , conduit-extra
+                     , filepath
+                     , minio-hs
+                     , optparse-applicative
+                     , text
+                     , time
+                     , unliftio
+                     , unordered-containers
+  hs-source-dirs:      examples
+  if !flag(examples)
+    buildable: False
+
+executable BucketExists
+  import:              examples-settings
+  scope:               private
+  main-is:             BucketExists.hs
+
+executable CopyObject
+  import:              examples-settings
+  scope:               private
+  main-is:             CopyObject.hs
+
+executable FileUploader
+  import:              examples-settings
+  scope:               private
+  main-is:             FileUploader.hs
+
+executable GetConfig
+  import:              examples-settings
+  scope:               private
+  main-is:             GetConfig.hs
+
+executable GetObject
+  import:              examples-settings
+  scope:               private
+  main-is:             GetObject.hs
+
+executable HeadObject
+  import:              examples-settings
+  scope:               private
+  main-is:             HeadObject.hs
+
+executable Heal
+  import:              examples-settings
+  scope:               private
+  main-is:             Heal.hs
+
+executable ListBuckets
+  import:              examples-settings
+  scope:               private
+  main-is:             ListBuckets.hs
+
+executable ListIncompleteUploads
+  import:              examples-settings
+  scope:               private
+  main-is:             ListIncompleteUploads.hs
+
+executable ListObjects
+  import:              examples-settings
+  scope:               private
+  main-is:             ListObjects.hs
+
+executable MakeBucket
+  import:              examples-settings
+  scope:               private
+  main-is:             MakeBucket.hs
+
+executable PresignedGetObject
+  import:              examples-settings
+  scope:               private
+  main-is:             PresignedGetObject.hs
+
+executable PresignedPostPolicy
+  import:              examples-settings
+  scope:               private
+  main-is:             PresignedPostPolicy.hs
+
+executable PresignedPutObject
+  import:              examples-settings
+  scope:               private
+  main-is:             PresignedPutObject.hs
+
+executable PutObject
+  import:              examples-settings
+  scope:               private
+  main-is:             PutObject.hs
+
+executable RemoveBucket
+  import:              examples-settings
+  scope:               private
+  main-is:             RemoveBucket.hs
+
+executable RemoveIncompleteUpload
+  import:              examples-settings
+  scope:               private
+  main-is:             RemoveIncompleteUpload.hs
+
+executable RemoveObject
+  import:              examples-settings
+  scope:               private
+  main-is:             RemoveObject.hs
+
+executable SelectObject
+  import:              examples-settings
+  scope:               private
+  main-is:             SelectObject.hs
+
+executable ServerInfo
+  import:              examples-settings
+  scope:               private
+  main-is:             ServerInfo.hs
+
+executable ServiceSendRestart
+  import:              examples-settings
+  scope:               private
+  main-is:             ServiceSendRestart.hs
+
+executable ServiceSendStop
+  import:              examples-settings
+  scope:               private
+  main-is:             ServiceSendStop.hs
+
+executable ServiceStatus
+  import:              examples-settings
+  scope:               private
+  main-is:             ServiceStatus.hs
+
+executable SetConfig
+  import:              examples-settings
+  scope:               private
+  main-is:             SetConfig.hs
 
 source-repository head
   type:     git

--- a/minio-hs.cabal
+++ b/minio-hs.cabal
@@ -93,7 +93,7 @@ library
                      , TupleSections
 
 Flag live-test
-  Default: True
+  Default: False
   Manual: True
 
 test-suite minio-hs-live-server-test


### PR DESCRIPTION
- Disable building live-server tests by default; build only in CI
- Update examples and README
- Build examples in CI via new opt-in cabal flag
- Drop GHC 8.2.2 support
- Update version for new release