### PR TITLE
Exclude content size from head request.

### DIFF
--- a/src/Network/Minio.hs
+++ b/src/Network/Minio.hs
@@ -93,6 +93,13 @@ module Network.Minio
   , oiUserMetadata
   , oiMetadata
 
+  , HeadInfo
+  , hiObject
+  , hiModTime
+  , hiETag
+  , hiUserMetadata
+  , hiMetadata
+
   -- ** Listing incomplete uploads
   , listIncompleteUploads
   , UploadId
@@ -283,7 +290,7 @@ getObject bucket object opts =
 
 -- | Get an object's metadata from the object store. It accepts the
 -- same options as GetObject.
-statObject :: Bucket -> Object -> GetObjectOptions -> Minio ObjectInfo
+statObject :: Bucket -> Object -> GetObjectOptions -> Minio HeadInfo
 statObject b o opts = headObject b o $ gooToHeaders opts
 
 -- | Creates a new bucket in the object store. The Region can be

--- a/src/Network/Minio/Data.hs
+++ b/src/Network/Minio/Data.hs
@@ -441,6 +441,24 @@ data ListObjectsV1Result = ListObjectsV1Result {
   } deriving (Show, Eq)
 
 -- | Represents information about an object.
+data HeadInfo = HeadInfo
+  { hiObject       :: Object -- ^ Object key
+  , hiModTime      :: UTCTime -- ^ Modification time of the object
+  , hiETag         :: ETag -- ^ ETag of the object
+  , hiUserMetadata :: H.HashMap Text Text -- ^ A map of user-metadata
+                                          -- pairs stored with an
+                                          -- object (keys will not
+                                          -- have the @X-Amz-Meta-@
+                                          -- prefix).
+  , hiMetadata     :: H.HashMap Text Text -- ^ A map of metadata
+                                          -- key-value pairs (not
+                                          -- including the
+                                          -- user-metadata pairs)
+  } deriving (Show, Eq)
+
+
+-- | Represents information about an object.
+--
 data ObjectInfo = ObjectInfo
   { oiObject       :: Object -- ^ Object key
   , oiModTime      :: UTCTime -- ^ Modification time of the object


### PR DESCRIPTION
Servers are not required to send content-length for head
request. It may happen for example in case if Accept-Encoding is set to gzip
(this is a default in http-client) and server decided that it will gzip
the file.

So solution is to create new type 'HeadInfo' that will not keep 'hiSize'
field that is not reliable.