### PR TITLE
Fix XML generation test for S3 SELECT

### DIFF
--- a/src/Network/Minio/Data.hs
+++ b/src/Network/Minio/Data.hs
@@ -155,11 +155,13 @@ fromAWSConfigFile = do
     bool (throwE "FileNotFound") (return ()) fileExists
     ini <- ExceptT $ Ini.readIniFile awsCredsFile
     akey <-
-      ExceptT $ return $
-        Ini.lookupValue "default" "aws_access_key_id" ini
+      ExceptT $
+        return $
+          Ini.lookupValue "default" "aws_access_key_id" ini
     skey <-
-      ExceptT $ return $
-        Ini.lookupValue "default" "aws_secret_access_key" ini
+      ExceptT $
+        return $
+          Ini.lookupValue "default" "aws_secret_access_key" ini
     return $ Credentials akey skey
   return $ hush credsE
 
@@ -856,6 +858,9 @@ instance Monoid CSVProp where
     mappend (CSVProp a) (CSVProp b) = CSVProp (b <> a)
 #endif
 
+csvPropsList :: CSVProp -> [(Text, Text)]
+csvPropsList (CSVProp h) = sort $ H.toList h
+
 defaultCSVProp :: CSVProp
 defaultCSVProp = mempty
 
@@ -929,10 +934,11 @@ type CSVOutputProp = CSVProp
 
 -- | quoteFields is an output serialization parameter
 quoteFields :: QuoteFields -> CSVProp
-quoteFields q = CSVProp $ H.singleton "QuoteFields" $
-  case q of
-    QuoteFieldsAsNeeded -> "ASNEEDED"
-    QuoteFieldsAlways -> "ALWAYS"
+quoteFields q = CSVProp $
+  H.singleton "QuoteFields" $
+    case q of
+      QuoteFieldsAsNeeded -> "ASNEEDED"
+      QuoteFieldsAlways -> "ALWAYS"
 
 -- | Represent the QuoteField setting.
 data QuoteFields = QuoteFieldsAsNeeded | QuoteFieldsAlways

--- a/test/Network/Minio/XmlGenerator/Test.hs
+++ b/test/Network/Minio/XmlGenerator/Test.hs
@@ -90,11 +90,12 @@ testMkPutNotificationRequest =
               "1"
               "arn:aws:sqs:us-west-2:444455556666:s3notificationqueue"
               [ObjectCreatedPut]
-              ( Filter $ FilterKey $
-                  FilterRules
-                    [ FilterRule "prefix" "images/",
-                      FilterRule "suffix" ".jpg"
-                    ]
+              ( Filter $
+                  FilterKey $
+                    FilterRules
+                      [ FilterRule "prefix" "images/",
+                        FilterRule "suffix" ".jpg"
+                      ]
               ),
             NotificationConfig
               ""
@@ -142,32 +143,32 @@ testMkSelectRequest = mapM_ assertFn cases
                   <> quoteEscapeCharacter "\""
             )
             (Just False),
-          [r|<?xml version="1.0" encoding="UTF-8"?><SelectRequest><Expression>Select * from S3Object</Expression><ExpressionType>SQL</ExpressionType><InputSerialization><CompressionType>GZIP</CompressionType><CSV><QuoteCharacter>&#34;</QuoteCharacter><RecordDelimiter>
-</RecordDelimiter><FileHeaderInfo>IGNORE</FileHeaderInfo><QuoteEscapeCharacter>&#34;</QuoteEscapeCharacter><FieldDelimiter>,</FieldDelimiter></CSV></InputSerialization><OutputSerialization><CSV><QuoteCharacter>&#34;</QuoteCharacter><QuoteFields>ASNEEDED</QuoteFields><RecordDelimiter>
-</RecordDelimiter><QuoteEscapeCharacter>&#34;</QuoteEscapeCharacter><FieldDelimiter>,</FieldDelimiter></CSV></OutputSerialization><RequestProgress><Enabled>FALSE</Enabled></RequestProgress></SelectRequest>|]
+          [r|<?xml version="1.0" encoding="UTF-8"?><SelectRequest><Expression>Select * from S3Object</Expression><ExpressionType>SQL</ExpressionType><InputSerialization><CompressionType>GZIP</CompressionType><CSV><FieldDelimiter>,</FieldDelimiter><FileHeaderInfo>IGNORE</FileHeaderInfo><QuoteCharacter>&#34;</QuoteCharacter><QuoteEscapeCharacter>&#34;</QuoteEscapeCharacter><RecordDelimiter>
+</RecordDelimiter></CSV></InputSerialization><OutputSerialization><CSV><FieldDelimiter>,</FieldDelimiter><QuoteCharacter>&#34;</QuoteCharacter><QuoteEscapeCharacter>&#34;</QuoteEscapeCharacter><QuoteFields>ASNEEDED</QuoteFields><RecordDelimiter>
+</RecordDelimiter></CSV></OutputSerialization><RequestProgress><Enabled>FALSE</Enabled></RequestProgress></SelectRequest>|]
         ),
-        ( setRequestProgressEnabled False
-            $ setInputCompressionType CompressionTypeGzip
-            $ selectRequest
-              "Select * from S3Object"
-              documentJsonInput
-              (outputJSONFromRecordDelimiter "\n"),
+        ( setRequestProgressEnabled False $
+            setInputCompressionType CompressionTypeGzip $
+              selectRequest
+                "Select * from S3Object"
+                documentJsonInput
+                (outputJSONFromRecordDelimiter "\n"),
           [r|<?xml version="1.0" encoding="UTF-8"?><SelectRequest><Expression>Select * from S3Object</Expression><ExpressionType>SQL</ExpressionType><InputSerialization><CompressionType>GZIP</CompressionType><JSON><Type>DOCUMENT</Type></JSON></InputSerialization><OutputSerialization><JSON><RecordDelimiter>
 </RecordDelimiter></JSON></OutputSerialization><RequestProgress><Enabled>FALSE</Enabled></RequestProgress></SelectRequest>|]
         ),
-        ( setRequestProgressEnabled False
-            $ setInputCompressionType CompressionTypeNone
-            $ selectRequest
-              "Select * from S3Object"
-              defaultParquetInput
-              ( outputCSVFromProps $
-                  quoteFields QuoteFieldsAsNeeded
-                    <> recordDelimiter "\n"
-                    <> fieldDelimiter ","
-                    <> quoteCharacter "\""
-                    <> quoteEscapeCharacter "\""
-              ),
-          [r|<?xml version="1.0" encoding="UTF-8"?><SelectRequest><Expression>Select * from S3Object</Expression><ExpressionType>SQL</ExpressionType><InputSerialization><CompressionType>NONE</CompressionType><Parquet/></InputSerialization><OutputSerialization><CSV><QuoteCharacter>&#34;</QuoteCharacter><QuoteFields>ASNEEDED</QuoteFields><RecordDelimiter>
-</RecordDelimiter><QuoteEscapeCharacter>&#34;</QuoteEscapeCharacter><FieldDelimiter>,</FieldDelimiter></CSV></OutputSerialization><RequestProgress><Enabled>FALSE</Enabled></RequestProgress></SelectRequest>|]
+        ( setRequestProgressEnabled False $
+            setInputCompressionType CompressionTypeNone $
+              selectRequest
+                "Select * from S3Object"
+                defaultParquetInput
+                ( outputCSVFromProps $
+                    quoteFields QuoteFieldsAsNeeded
+                      <> recordDelimiter "\n"
+                      <> fieldDelimiter ","
+                      <> quoteCharacter "\""
+                      <> quoteEscapeCharacter "\""
+                ),
+          [r|<?xml version="1.0" encoding="UTF-8"?><SelectRequest><Expression>Select * from S3Object</Expression><ExpressionType>SQL</ExpressionType><InputSerialization><CompressionType>NONE</CompressionType><Parquet/></InputSerialization><OutputSerialization><CSV><FieldDelimiter>,</FieldDelimiter><QuoteCharacter>&#34;</QuoteCharacter><QuoteEscapeCharacter>&#34;</QuoteEscapeCharacter><QuoteFields>ASNEEDED</QuoteFields><RecordDelimiter>
+</RecordDelimiter></CSV></OutputSerialization><RequestProgress><Enabled>FALSE</Enabled></RequestProgress></SelectRequest>|]
         )
       ]


### PR DESCRIPTION
- Test was failing because of non-unique ordering of CSV properties. It is fixed
by sorting the CSV properties before serialization.