### PR TITLE
Use region specific endpoints for AWS S3 in presigned Urls

### DIFF
--- a/minio-hs.cabal
+++ b/minio-hs.cabal
@@ -77,6 +77,7 @@ common base-settings
                      , http-types >= 0.12
                      , ini
                      , memory >= 0.14
+                     , network-uri
                      , raw-strings-qq >= 1
                      , resourcet >= 1.2
                      , retry

--- a/src/Network/Minio/APICommon.hs
+++ b/src/Network/Minio/APICommon.hs
@@ -20,6 +20,7 @@ import qualified Conduit as C
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LB
 import Data.Conduit.Binary (sourceHandleRange)
+import qualified Data.Text as T
 import Lib.Prelude
 import qualified Network.HTTP.Conduit as NC
 import qualified Network.HTTP.Types as HT
@@ -70,3 +71,10 @@ mkStreamingPayload payload =
 isStreamingPayload :: Payload -> Bool
 isStreamingPayload (PayloadC _ _) = True
 isStreamingPayload _ = False
+
+-- | Checks if the connect info is for Amazon S3.
+isAWSConnectInfo :: ConnectInfo -> Bool
+isAWSConnectInfo ci = ".amazonaws.com" `T.isSuffixOf` connectHost ci
+
+bucketHasPeriods :: Bucket -> Bool
+bucketHasPeriods b = isJust $ T.find (== '.') b

--- a/src/Network/Minio/Data.hs
+++ b/src/Network/Minio/Data.hs
@@ -49,6 +49,7 @@ import Network.HTTP.Types
   )
 import qualified Network.HTTP.Types as HT
 import Network.Minio.Data.Crypto
+import Network.Minio.Data.Time
 import Network.Minio.Errors
 import System.Directory (doesFileExist, getHomeDirectory)
 import qualified System.Environment as Env
@@ -79,20 +80,20 @@ maxMultipartParts = 10000
 awsRegionMap :: H.HashMap Text Text
 awsRegionMap =
   H.fromList
-    [ ("us-east-1", "s3.amazonaws.com"),
-      ("us-east-2", "s3-us-east-2.amazonaws.com"),
-      ("us-west-1", "s3-us-west-1.amazonaws.com"),
-      ("us-west-2", "s3-us-west-2.amazonaws.com"),
-      ("ca-central-1", "s3-ca-central-1.amazonaws.com"),
-      ("ap-south-1", "s3-ap-south-1.amazonaws.com"),
-      ("ap-northeast-1", "s3-ap-northeast-1.amazonaws.com"),
-      ("ap-northeast-2", "s3-ap-northeast-2.amazonaws.com"),
-      ("ap-southeast-1", "s3-ap-southeast-1.amazonaws.com"),
-      ("ap-southeast-2", "s3-ap-southeast-2.amazonaws.com"),
-      ("eu-west-1", "s3-eu-west-1.amazonaws.com"),
-      ("eu-west-2", "s3-eu-west-2.amazonaws.com"),
-      ("eu-central-1", "s3-eu-central-1.amazonaws.com"),
-      ("sa-east-1", "s3-sa-east-1.amazonaws.com")
+    [ ("us-east-1", "s3.us-east-1.amazonaws.com"),
+      ("us-east-2", "s3.us-east-2.amazonaws.com"),
+      ("us-west-1", "s3.us-west-1.amazonaws.com"),
+      ("us-west-2", "s3.us-west-2.amazonaws.com"),
+      ("ca-central-1", "s3.ca-central-1.amazonaws.com"),
+      ("ap-south-1", "s3.ap-south-1.amazonaws.com"),
+      ("ap-northeast-1", "s3.ap-northeast-1.amazonaws.com"),
+      ("ap-northeast-2", "s3.ap-northeast-2.amazonaws.com"),
+      ("ap-southeast-1", "s3.ap-southeast-1.amazonaws.com"),
+      ("ap-southeast-2", "s3.ap-southeast-2.amazonaws.com"),
+      ("eu-west-1", "s3.eu-west-1.amazonaws.com"),
+      ("eu-west-2", "s3.eu-west-2.amazonaws.com"),
+      ("eu-central-1", "s3.eu-central-1.amazonaws.com"),
+      ("sa-east-1", "s3.sa-east-1.amazonaws.com")
     ]
 
 -- | Connection Info data type. To create a 'ConnectInfo' value,
@@ -1022,7 +1023,8 @@ data S3ReqInfo = S3ReqInfo
     riPayload :: Payload,
     riPayloadHash :: Maybe ByteString,
     riRegion :: Maybe Region,
-    riNeedsLocation :: Bool
+    riNeedsLocation :: Bool,
+    riPresignExpirySecs :: Maybe UrlExpiry
   }
 
 defaultS3ReqInfo :: S3ReqInfo
@@ -1037,15 +1039,12 @@ defaultS3ReqInfo =
     Nothing
     Nothing
     True
+    Nothing
 
 getS3Path :: Maybe Bucket -> Maybe Object -> ByteString
 getS3Path b o =
   let segments = map toUtf8 $ catMaybes $ b : bool [] [o] (isJust b)
    in B.concat ["/", B.intercalate "/" segments]
-
--- | Time to expire for a presigned URL. It interpreted as a number of
--- seconds. The maximum duration that can be specified is 7 days.
-type UrlExpiry = Int
 
 type RegionMap = H.HashMap Bucket Region
 

--- a/src/Network/Minio/Data/Time.hs
+++ b/src/Network/Minio/Data/Time.hs
@@ -21,12 +21,17 @@ module Network.Minio.Data.Time
     awsDateFormatBS,
     awsParseTime,
     iso8601TimeFormat,
+    UrlExpiry,
   )
 where
 
 import Data.ByteString.Char8 (pack)
 import qualified Data.Time as Time
 import Lib.Prelude
+
+-- | Time to expire for a presigned URL. It interpreted as a number of
+-- seconds. The maximum duration that can be specified is 7 days.
+type UrlExpiry = Int
 
 awsTimeFormat :: UTCTime -> [Char]
 awsTimeFormat = Time.formatTime Time.defaultTimeLocale "%Y%m%dT%H%M%SZ"

--- a/src/Network/Minio/Sign/V4.hs
+++ b/src/Network/Minio/Sign/V4.hs
@@ -65,7 +65,7 @@ data SignParams = SignParams
     spSecretKey :: Text,
     spTimeStamp :: UTCTime,
     spRegion :: Maybe Text,
-    spExpirySecs :: Maybe Int,
+    spExpirySecs :: Maybe UrlExpiry,
     spPayloadHash :: Maybe ByteString
   }
   deriving (Show)

--- a/test/LiveServer.hs
+++ b/test/LiveServer.hs
@@ -34,7 +34,6 @@ import qualified Network.HTTP.Types as HT
 import Network.Minio
 import Network.Minio.Data
 import Network.Minio.Data.Crypto
-import Network.Minio.PutObject
 import Network.Minio.S3API
 import Network.Minio.Utils
 import System.Directory (getTemporaryDirectory)


### PR DESCRIPTION
- Also update standard S3 endpoints

- Unify code that determines if path style or virtual style must be used for
regular and presigned requests