### PR TITLE
Replace protolude with relude and build with GHC 9.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         os: [ubuntu-latest, windows-latest] # Removed macos-latest due to cert issues.
         cabal: ["3.6"]
         ghc:
-          # - "9.0.1"
+          - "9.0.2"
           - "8.10.7"
           - "8.8.4"
           - "8.6.5"
@@ -122,13 +122,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        stack: ["2.3.1"]
-        ghc: ["8.8.4"]
+        stack: ["2.7.3"]
+        ghc: ["8.10.7"]
         os: [ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v2
-      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'
+      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
     - uses: haskell/actions/setup@v1
       name: Setup Haskell Stack

--- a/examples/FileUploader.hs
+++ b/examples/FileUploader.hs
@@ -19,7 +19,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-import Data.Monoid ((<>))
 import Data.Text (pack)
 import Network.Minio
 import Options.Applicative

--- a/minio-hs.cabal
+++ b/minio-hs.cabal
@@ -21,22 +21,52 @@ extra-source-files:
                    examples/*.hs
                    README.md
                    stack.yaml
+tested-with:         GHC == 8.8.4
+                   , GHC == 8.10.7
+                   , GHC == 9.0.2
+
+source-repository head
+  type:                git
+  location:            https://github.com/minio/minio-hs.git
 
 
 common base-settings
   ghc-options:         -Wall
+                       -Wcompat
+                       -Widentities
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -haddock
+  if impl(ghc >= 8.0)
+    ghc-options:       -Wredundant-constraints
+  if impl(ghc >= 8.2)
+    ghc-options:       -fhide-source-paths
+
+  -- Add this when we have time. Fixing partial-fields requires major version
+  -- bump at this time.
+  -- if impl(ghc >= 8.4)
+  --   ghc-options:       -Wpartial-fields
+  --                      -Wmissing-export-lists
+
+  if impl(ghc >= 8.8)
+    ghc-options:       -Wmissing-deriving-strategies
+                       -Werror=missing-deriving-strategies
+
   default-language:    Haskell2010
+
   default-extensions:  BangPatterns
+                     , DerivingStrategies
                      , FlexibleContexts
                      , FlexibleInstances
                      , MultiParamTypeClasses
                      , MultiWayIf
-                     , NoImplicitPrelude
                      , OverloadedStrings
                      , RankNTypes
                      , ScopedTypeVariables
-                     , TypeFamilies
                      , TupleSections
+                     , TypeFamilies
+
+
   other-modules:       Lib.Prelude
                      , Network.Minio.API
                      , Network.Minio.APICommon
@@ -55,8 +85,13 @@ common base-settings
                      , Network.Minio.XmlGenerator
                      , Network.Minio.XmlParser
                      , Network.Minio.JsonParser
+
+  mixins:              base hiding (Prelude)
+                     , relude (Relude as Prelude)
+                     , relude
+
   build-depends:       base >= 4.7 && < 5
-                     , protolude >= 0.3 && < 0.4
+                     , relude >= 0.7 && < 2
                      , aeson >= 1.2 && < 2
                      , base64-bytestring >= 1.0
                      , binary >= 0.8.5.0
@@ -292,7 +327,3 @@ executable SetConfig
   import:              examples-settings
   scope:               private
   main-is:             SetConfig.hs
-
-source-repository head
-  type:     git
-  location: https://github.com/minio/minio-hs

--- a/src/Lib/Prelude.hs
+++ b/src/Lib/Prelude.hs
@@ -20,6 +20,7 @@ module Lib.Prelude
     showBS,
     toStrictBS,
     fromStrictBS,
+    lastMay,
   )
 where
 
@@ -28,14 +29,6 @@ import qualified Data.ByteString.Lazy as LB
 import Data.Time as Exports
   ( UTCTime (..),
     diffUTCTime,
-  )
-import Protolude as Exports hiding
-  ( Handler,
-    catch,
-    catches,
-    throwIO,
-    try,
-    yield,
   )
 import UnliftIO as Exports
   ( Handler,
@@ -50,10 +43,13 @@ both :: (a -> b) -> (a, a) -> (b, b)
 both f (a, b) = (f a, f b)
 
 showBS :: Show a => a -> ByteString
-showBS a = toUtf8 (show a :: Text)
+showBS a = encodeUtf8 (show a :: Text)
 
 toStrictBS :: LByteString -> ByteString
 toStrictBS = LB.toStrict
 
 fromStrictBS :: ByteString -> LByteString
 fromStrictBS = LB.fromStrict
+
+lastMay :: [a] -> Maybe a
+lastMay a = last <$> nonEmpty a

--- a/src/Network/Minio.hs
+++ b/src/Network/Minio.hs
@@ -225,7 +225,6 @@ This module exports the high-level MinIO API for object storage.
 import qualified Data.Conduit as C
 import qualified Data.Conduit.Binary as CB
 import qualified Data.Conduit.Combinators as CC
-import Lib.Prelude
 import Network.Minio.CopyObject
 import Network.Minio.Data
 import Network.Minio.Errors

--- a/src/Network/Minio/APICommon.hs
+++ b/src/Network/Minio/APICommon.hs
@@ -46,7 +46,7 @@ getPayloadSHA256Hash (PayloadC _ _) = throwIO MErrVUnexpectedPayload
 getRequestBody :: Payload -> NC.RequestBody
 getRequestBody (PayloadBS bs) = NC.RequestBodyBS bs
 getRequestBody (PayloadH h off size) =
-  NC.requestBodySource (fromIntegral size) $
+  NC.requestBodySource size $
     sourceHandleRange
       h
       (return . fromIntegral $ off)

--- a/src/Network/Minio/AdminAPI.hs
+++ b/src/Network/Minio/AdminAPI.hs
@@ -90,7 +90,7 @@ data DriveInfo = DriveInfo
     diEndpoint :: Text,
     diState :: Text
   }
-  deriving (Eq, Show)
+  deriving stock (Show, Eq)
 
 instance FromJSON DriveInfo where
   parseJSON = withObject "DriveInfo" $ \v ->
@@ -103,7 +103,7 @@ data StorageClass = StorageClass
   { scParity :: Int,
     scData :: Int
   }
-  deriving (Eq, Show)
+  deriving stock (Show, Eq)
 
 data ErasureInfo = ErasureInfo
   { eiOnlineDisks :: Int,
@@ -112,7 +112,7 @@ data ErasureInfo = ErasureInfo
     eiReducedRedundancy :: StorageClass,
     eiSets :: [[DriveInfo]]
   }
-  deriving (Eq, Show)
+  deriving stock (Show, Eq)
 
 instance FromJSON ErasureInfo where
   parseJSON = withObject "ErasureInfo" $ \v -> do
@@ -132,7 +132,7 @@ instance FromJSON ErasureInfo where
 data Backend
   = BackendFS
   | BackendErasure ErasureInfo
-  deriving (Eq, Show)
+  deriving stock (Show, Eq)
 
 instance FromJSON Backend where
   parseJSON = withObject "Backend" $ \v -> do
@@ -146,7 +146,7 @@ data ConnStats = ConnStats
   { csTransferred :: Int64,
     csReceived :: Int64
   }
-  deriving (Eq, Show)
+  deriving stock (Show, Eq)
 
 instance FromJSON ConnStats where
   parseJSON = withObject "ConnStats" $ \v ->
@@ -161,7 +161,7 @@ data ServerProps = ServerProps
     spRegion :: Text,
     spSqsArns :: [Text]
   }
-  deriving (Eq, Show)
+  deriving stock (Show, Eq)
 
 instance FromJSON ServerProps where
   parseJSON = withObject "SIServer" $ \v -> do
@@ -177,7 +177,7 @@ data StorageInfo = StorageInfo
   { siUsed :: Int64,
     siBackend :: Backend
   }
-  deriving (Eq, Show)
+  deriving stock (Show, Eq)
 
 instance FromJSON StorageInfo where
   parseJSON = withObject "StorageInfo" $ \v ->
@@ -189,7 +189,7 @@ data CountNAvgTime = CountNAvgTime
   { caCount :: Int64,
     caAvgDuration :: Text
   }
-  deriving (Eq, Show)
+  deriving stock (Show, Eq)
 
 instance FromJSON CountNAvgTime where
   parseJSON = withObject "CountNAvgTime" $ \v ->
@@ -209,7 +209,7 @@ data HttpStats = HttpStats
     hsTotalDeletes :: CountNAvgTime,
     hsSuccessDeletes :: CountNAvgTime
   }
-  deriving (Eq, Show)
+  deriving stock (Show, Eq)
 
 instance FromJSON HttpStats where
   parseJSON = withObject "HttpStats" $ \v ->
@@ -231,7 +231,7 @@ data SIData = SIData
     sdHttpStats :: HttpStats,
     sdProps :: ServerProps
   }
-  deriving (Eq, Show)
+  deriving stock (Show, Eq)
 
 instance FromJSON SIData where
   parseJSON = withObject "SIData" $ \v ->
@@ -246,7 +246,7 @@ data ServerInfo = ServerInfo
     siAddr :: Text,
     siData :: SIData
   }
-  deriving (Eq, Show)
+  deriving stock (Show, Eq)
 
 instance FromJSON ServerInfo where
   parseJSON = withObject "ServerInfo" $ \v ->
@@ -259,7 +259,7 @@ data ServerVersion = ServerVersion
   { svVersion :: Text,
     svCommitId :: Text
   }
-  deriving (Eq, Show)
+  deriving stock (Show, Eq)
 
 instance FromJSON ServerVersion where
   parseJSON = withObject "ServerVersion" $ \v ->
@@ -271,7 +271,7 @@ data ServiceStatus = ServiceStatus
   { ssVersion :: ServerVersion,
     ssUptime :: NominalDiffTime
   }
-  deriving (Eq, Show)
+  deriving stock (Show, Eq)
 
 instance FromJSON ServiceStatus where
   parseJSON = withObject "ServiceStatus" $ \v -> do
@@ -283,7 +283,7 @@ instance FromJSON ServiceStatus where
 data ServiceAction
   = ServiceActionRestart
   | ServiceActionStop
-  deriving (Eq, Show)
+  deriving stock (Show, Eq)
 
 instance ToJSON ServiceAction where
   toJSON a = object ["action" .= serviceActionToText a]
@@ -301,7 +301,7 @@ data HealStartResp = HealStartResp
     hsrClientAddr :: Text,
     hsrStartTime :: UTCTime
   }
-  deriving (Eq, Show)
+  deriving stock (Show, Eq)
 
 instance FromJSON HealStartResp where
   parseJSON = withObject "HealStartResp" $ \v ->
@@ -314,7 +314,7 @@ data HealOpts = HealOpts
   { hoRecursive :: Bool,
     hoDryRun :: Bool
   }
-  deriving (Eq, Show)
+  deriving stock (Show, Eq)
 
 instance ToJSON HealOpts where
   toJSON (HealOpts r d) =
@@ -333,7 +333,7 @@ data HealItemType
   | HealItemBucket
   | HealItemBucketMetadata
   | HealItemObject
-  deriving (Eq, Show)
+  deriving stock (Show, Eq)
 
 instance FromJSON HealItemType where
   parseJSON = withText "HealItemType" $ \v -> case v of
@@ -348,7 +348,7 @@ data NodeSummary = NodeSummary
     nsErrSet :: Bool,
     nsErrMessage :: Text
   }
-  deriving (Eq, Show)
+  deriving stock (Show, Eq)
 
 instance FromJSON NodeSummary where
   parseJSON = withObject "NodeSummary" $ \v ->
@@ -361,7 +361,7 @@ data SetConfigResult = SetConfigResult
   { scrStatus :: Bool,
     scrNodeSummary :: [NodeSummary]
   }
-  deriving (Eq, Show)
+  deriving stock (Show, Eq)
 
 instance FromJSON SetConfigResult where
   parseJSON = withObject "SetConfigResult" $ \v ->
@@ -383,7 +383,7 @@ data HealResultItem = HealResultItem
     hriBefore :: [DriveInfo],
     hriAfter :: [DriveInfo]
   }
-  deriving (Eq, Show)
+  deriving stock (Show, Eq)
 
 instance FromJSON HealResultItem where
   parseJSON = withObject "HealResultItem" $ \v ->
@@ -415,7 +415,7 @@ data HealStatus = HealStatus
     hsFailureDetail :: Maybe Text,
     hsItems :: Maybe [HealResultItem]
   }
-  deriving (Eq, Show)
+  deriving stock (Show, Eq)
 
 instance FromJSON HealStatus where
   parseJSON = withObject "HealStatus" $ \v ->
@@ -434,7 +434,7 @@ healPath bucket prefix = do
       encodeUtf8 $
         "v1/heal/" <> fromMaybe "" bucket <> "/"
           <> fromMaybe "" prefix
-    else encodeUtf8 $ "v1/heal/"
+    else encodeUtf8 ("v1/heal/" :: Text)
 
 -- | Get server version and uptime.
 serviceStatus :: Minio ServiceStatus

--- a/src/Network/Minio/Data/ByteString.hs
+++ b/src/Network/Minio/Data/ByteString.hs
@@ -25,9 +25,8 @@ import qualified Data.ByteString as B
 import qualified Data.ByteString.Builder as BB
 import qualified Data.ByteString.Char8 as BC8
 import qualified Data.ByteString.Lazy as LB
-import Data.Char (isAsciiLower, isAsciiUpper)
+import Data.Char (isAsciiLower, isAsciiUpper, isDigit, isSpace, toUpper)
 import qualified Data.Text as T
-import Lib.Prelude
 import Numeric (showHex)
 
 stripBS :: ByteString -> ByteString
@@ -73,4 +72,4 @@ uriEncodeChar ch _
     f n = BB.char7 '%' <> BB.string7 hexStr
       where
         hexStr = map toUpper $ showHex q $ showHex r ""
-        (q, r) = divMod (fromIntegral n) (16 :: Word8)
+        (q, r) = divMod n (16 :: Word8)

--- a/src/Network/Minio/Data/Crypto.hs
+++ b/src/Network/Minio/Data/Crypto.hs
@@ -39,7 +39,6 @@ import Crypto.MAC.HMAC (HMAC, hmac)
 import Data.ByteArray (ByteArrayAccess, convert)
 import Data.ByteArray.Encoding (Base (Base16, Base64), convertToBase)
 import qualified Data.Conduit as C
-import Lib.Prelude
 
 hashSHA256 :: ByteString -> ByteString
 hashSHA256 = digestToBase16 . hashWith SHA256

--- a/src/Network/Minio/Errors.hs
+++ b/src/Network/Minio/Errors.hs
@@ -14,10 +14,15 @@
 -- limitations under the License.
 --
 
-module Network.Minio.Errors where
+module Network.Minio.Errors
+  ( MErrV (..),
+    ServiceErr (..),
+    MinioErr (..),
+    toServiceErr,
+  )
+where
 
-import Control.Exception
-import Lib.Prelude
+import Control.Exception (IOException)
 import qualified Network.HTTP.Conduit as NC
 
 ---------------------------------
@@ -44,7 +49,7 @@ data MErrV
   | MErrVInvalidEncryptionKeyLength
   | MErrVStreamingBodyUnexpectedEOF
   | MErrVUnexpectedPayload
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 instance Exception MErrV
 
@@ -57,7 +62,7 @@ data ServiceErr
   | NoSuchKey
   | SelectErr Text Text
   | ServiceErr Text Text
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 instance Exception ServiceErr
 
@@ -75,7 +80,7 @@ data MinioErr
   | MErrIO IOException
   | MErrService ServiceErr
   | MErrValidation MErrV
-  deriving (Show)
+  deriving stock (Show)
 
 instance Eq MinioErr where
   MErrHTTP _ == MErrHTTP _ = True

--- a/src/Network/Minio/JsonParser.hs
+++ b/src/Network/Minio/JsonParser.hs
@@ -34,7 +34,7 @@ data AdminErrJSON = AdminErrJSON
   { aeCode :: Text,
     aeMessage :: Text
   }
-  deriving (Eq, Show)
+  deriving stock (Eq, Show)
 
 instance FromJSON AdminErrJSON where
   parseJSON = withObject "AdminErrJSON" $ \v ->

--- a/src/Network/Minio/PutObject.hs
+++ b/src/Network/Minio/PutObject.hs
@@ -77,7 +77,7 @@ putObjectInternal b o opts (ODStream src sizeMay) = do
           | otherwise -> sequentialMultipartUpload b o opts (Just size) src
 putObjectInternal b o opts (ODFile fp sizeMay) = do
   hResE <- withNewHandle fp $ \h ->
-    liftM2 (,) (isHandleSeekable h) (getFileSize h)
+    liftA2 (,) (isHandleSeekable h) (getFileSize h)
 
   (isSeekable, handleSizeMay) <-
     either

--- a/src/Network/Minio/S3API.hs
+++ b/src/Network/Minio/S3API.hs
@@ -380,7 +380,7 @@ putObjectPart bucket object uploadId partNumber headers payload = do
 srcInfoToHeaders :: SourceInfo -> [HT.Header]
 srcInfoToHeaders srcInfo =
   ( "x-amz-copy-source",
-    toUtf8 $
+    encodeUtf8 $
       T.concat
         [ "/",
           srcBucket srcInfo,

--- a/src/Network/Minio/SelectAPI.hs
+++ b/src/Network/Minio/SelectAPI.hs
@@ -111,7 +111,7 @@ data EventStreamException
   | ESEInvalidHeaderType
   | ESEInvalidHeaderValueType
   | ESEInvalidMessageType
-  deriving (Eq, Show)
+  deriving stock (Eq, Show)
 
 instance Exception EventStreamException
 
@@ -219,7 +219,7 @@ handleMessage = do
   hs <- parseHeaders hdrLen
 
   let payloadLen = msgLen - hdrLen - 16
-      getHdrVal h = fmap snd . headMay . filter ((h ==) . fst)
+      getHdrVal h = fmap snd . find ((h ==) . fst)
       eventHdrValue = getHdrVal EventType hs
       msgHdrValue = getHdrVal MessageType hs
       errCode = getHdrVal ErrorCode hs

--- a/src/Network/Minio/XmlGenerator.hs
+++ b/src/Network/Minio/XmlGenerator.hs
@@ -24,7 +24,6 @@ where
 
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as T
-import Lib.Prelude
 import Network.Minio.Data
 import Text.XML
 
@@ -72,7 +71,7 @@ mkCompleteMultipartUploadRequest partInfo =
 data XNode
   = XNode Text [XNode]
   | XLeaf Text Text
-  deriving (Eq, Show)
+  deriving stock (Eq, Show)
 
 toXML :: Text -> XNode -> ByteString
 toXML ns node =
@@ -94,7 +93,7 @@ class ToXNode a where
   toXNode :: a -> XNode
 
 instance ToXNode Event where
-  toXNode = XLeaf "Event" . show
+  toXNode = XLeaf "Event" . toText
 
 instance ToXNode Notification where
   toXNode (Notification qc tc lc) =
@@ -104,9 +103,9 @@ instance ToXNode Notification where
         ++ map (toXNodesWithArnName "CloudFunctionConfiguration" "CloudFunction") lc
 
 toXNodesWithArnName :: Text -> Text -> NotificationConfig -> XNode
-toXNodesWithArnName eltName arnName (NotificationConfig id arn events fRule) =
+toXNodesWithArnName eltName arnName (NotificationConfig itemId arn events fRule) =
   XNode eltName $
-    [XLeaf "Id" id, XLeaf arnName arn] ++ map toXNode events
+    [XLeaf "Id" itemId, XLeaf arnName arn] ++ map toXNode events
       ++ [toXNode fRule]
 
 instance ToXNode Filter where

--- a/src/Network/Minio/XmlParser.hs
+++ b/src/Network/Minio/XmlParser.hs
@@ -32,7 +32,7 @@ where
 
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.HashMap.Strict as H
-import Data.List (zip3, zip4, zip6)
+import Data.List (zip4, zip6)
 import qualified Data.Text as T
 import Data.Text.Read (decimal)
 import Data.Time
@@ -132,7 +132,7 @@ parseListObjectsV1Response xmldata = do
   ns <- asks getSvcNamespace
   let s3Elem' = s3Elem ns
       hasMore = ["true"] == (r $/ s3Elem' "IsTruncated" &/ content)
-      nextMarker = headMay $ r $/ s3Elem' "NextMarker" &/ content
+      nextMarker = listToMaybe $ r $/ s3Elem' "NextMarker" &/ content
       prefixes = r $/ s3Elem' "CommonPrefixes" &/ s3Elem' "Prefix" &/ content
       keys = r $/ s3Elem' "Contents" &/ s3Elem' "Key" &/ content
       modTimeStr = r $/ s3Elem' "Contents" &/ s3Elem' "LastModified" &/ content
@@ -158,7 +158,7 @@ parseListObjectsResponse xmldata = do
   ns <- asks getSvcNamespace
   let s3Elem' = s3Elem ns
       hasMore = ["true"] == (r $/ s3Elem' "IsTruncated" &/ content)
-      nextToken = headMay $ r $/ s3Elem' "NextContinuationToken" &/ content
+      nextToken = listToMaybe $ r $/ s3Elem' "NextContinuationToken" &/ content
       prefixes = r $/ s3Elem' "CommonPrefixes" &/ s3Elem' "Prefix" &/ content
       keys = r $/ s3Elem' "Contents" &/ s3Elem' "Key" &/ content
       modTimeStr = r $/ s3Elem' "Contents" &/ s3Elem' "LastModified" &/ content
@@ -185,8 +185,8 @@ parseListUploadsResponse xmldata = do
   let s3Elem' = s3Elem ns
       hasMore = ["true"] == (r $/ s3Elem' "IsTruncated" &/ content)
       prefixes = r $/ s3Elem' "CommonPrefixes" &/ s3Elem' "Prefix" &/ content
-      nextKey = headMay $ r $/ s3Elem' "NextKeyMarker" &/ content
-      nextUpload = headMay $ r $/ s3Elem' "NextUploadIdMarker" &/ content
+      nextKey = listToMaybe $ r $/ s3Elem' "NextKeyMarker" &/ content
+      nextUpload = listToMaybe $ r $/ s3Elem' "NextUploadIdMarker" &/ content
       uploadKeys = r $/ s3Elem' "Upload" &/ s3Elem' "Key" &/ content
       uploadIds = r $/ s3Elem' "Upload" &/ s3Elem' "UploadId" &/ content
       uploadInitTimeStr = r $/ s3Elem' "Upload" &/ s3Elem' "Initiated" &/ content
@@ -203,7 +203,7 @@ parseListPartsResponse xmldata = do
   ns <- asks getSvcNamespace
   let s3Elem' = s3Elem ns
       hasMore = ["true"] == (r $/ s3Elem' "IsTruncated" &/ content)
-      nextPartNumStr = headMay $ r $/ s3Elem' "NextPartNumberMarker" &/ content
+      nextPartNumStr = listToMaybe $ r $/ s3Elem' "NextPartNumberMarker" &/ content
       partNumberStr = r $/ s3Elem' "Part" &/ s3Elem' "PartNumber" &/ content
       partModTimeStr = r $/ s3Elem' "Part" &/ s3Elem' "LastModified" &/ content
       partETags = r $/ s3Elem' "Part" &/ s3Elem' "ETag" &/ content
@@ -245,7 +245,7 @@ parseNotification xmldata = do
        in FilterRule name value
     parseNode ns arnName nodeData = do
       let c = fromNode nodeData
-          id = T.concat $ c $/ s3Elem ns "Id" &/ content
+          itemId = T.concat $ c $/ s3Elem ns "Id" &/ content
           arn = T.concat $ c $/ s3Elem ns arnName &/ content
           events = catMaybes $ map textToEvent $ c $/ s3Elem ns "Event" &/ content
           rules =
@@ -253,7 +253,7 @@ parseNotification xmldata = do
               &/ s3Elem ns "FilterRule" &| getFilterRule ns
       return $
         NotificationConfig
-          id
+          itemId
           arn
           events
           (Filter $ FilterKey $ FilterRules rules)

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-16.0
+resolver: lts-18.24
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -39,9 +39,7 @@ packages:
 - '.'
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps:
-- unliftio-core-0.2.0.1
-- protolude-0.3.0
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,24 +3,10 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    hackage: unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
-    pantry-tree:
-      size: 328
-      sha256: e81c5a1e82ec2cd68cbbbec9cd60567363abe02257fa1370a906f6754b6818b8
-  original:
-    hackage: unliftio-core-0.2.0.1
-- completed:
-    hackage: protolude-0.3.0@sha256:8361b811b420585b122a7ba715aa5923834db6e8c36309bf267df2dbf66b95ef,2693
-    pantry-tree:
-      size: 1644
-      sha256: babf32b414f25f790b7a4ce6bae5c960bc51a11a289e7c47335b222e6762560c
-  original:
-    hackage: protolude-0.3.0
+packages: []
 snapshots:
 - completed:
-    size: 531237
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/0.yaml
-    sha256: 210e15b7043e2783115afe16b0d54914b1611cdaa73f3ca3ca7f8e0847ff54e5
-  original: lts-16.0
+    size: 587821
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/24.yaml
+    sha256: 06d844ba51e49907bd29cb58b4a5f86ee7587a4cd7e6cf395eeec16cba619ce8
+  original: lts-18.24

--- a/test/Network/Minio/API/Test.hs
+++ b/test/Network/Minio/API/Test.hs
@@ -24,7 +24,6 @@ module Network.Minio.API.Test
 where
 
 import Data.Aeson (eitherDecode)
-import Lib.Prelude
 import Network.Minio.API
 import Network.Minio.AdminAPI
 import Test.Tasty

--- a/test/Network/Minio/TestHelpers.hs
+++ b/test/Network/Minio/TestHelpers.hs
@@ -19,7 +19,6 @@ module Network.Minio.TestHelpers
   )
 where
 
-import Lib.Prelude
 import Network.Minio.Data
 
 newtype TestNS = TestNS {testNamespace :: Text}

--- a/test/Network/Minio/Utils/Test.hs
+++ b/test/Network/Minio/Utils/Test.hs
@@ -19,7 +19,6 @@ module Network.Minio.Utils.Test
   )
 where
 
-import Lib.Prelude
 import Network.Minio.Utils
 import Test.Tasty
 import Test.Tasty.HUnit

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -73,10 +73,10 @@ qcProps =
                 if
                     | nparts > 1 -> -- last part can be smaller but > 0
                         all (>= minPartSize) (take (nparts - 1) sizes)
-                          && all (\s -> s > 0) (drop (nparts - 1) sizes)
+                          && all (> 0) (drop (nparts - 1) sizes)
                     | nparts == 1 -> -- size may be 0 here.
                         maybe True (\x -> x >= 0 && x <= minPartSize) $
-                          headMay sizes
+                          listToMaybe sizes
                     | otherwise -> False
            in n < 0
                 || ( isPNumsAscendingFrom1 && isOffsetsAsc && isSumSizeOk
@@ -89,16 +89,16 @@ qcProps =
               -- is last part's snd offset end?
               isLastPartOk = maybe False ((end ==) . snd) $ lastMay pairs
               -- is first part's fst offset start
-              isFirstPartOk = maybe False ((start ==) . fst) $ headMay pairs
+              isFirstPartOk = maybe False ((start ==) . fst) $ listToMaybe pairs
               -- each pair is >=64MiB except last, and all those parts
               -- have same size.
-              initSizes = maybe [] (map (\(a, b) -> b - a + 1)) $ initMay pairs
+              initSizes = maybe [] (map (\(a, b) -> b - a + 1)) $ init <$> nonEmpty pairs
               isPartSizesOk =
                 all (>= minPartSize) initSizes
                   && maybe
                     True
                     (\k -> all (== k) initSizes)
-                    (headMay initSizes)
+                    (listToMaybe initSizes)
               -- returned offsets are contiguous.
               fsts = drop 1 $ map fst pairs
               snds = take (length pairs - 1) $ map snd pairs


### PR DESCRIPTION
- relude is a better and more commonly used library

- Add compiler warnings and fixes

- Update stack lts to 18.24

- Add explicit deriving strategies