### PR TITLE
Support Aeson 2

### DIFF
--- a/minio-hs.cabal
+++ b/minio-hs.cabal
@@ -92,7 +92,7 @@ common base-settings
 
   build-depends:       base >= 4.7 && < 5
                      , relude >= 0.7 && < 2
-                     , aeson >= 1.2 && < 2
+                     , aeson >= 1.2 && < 3
                      , base64-bytestring >= 1.0
                      , binary >= 0.8.5.0
                      , bytestring >= 0.10

--- a/src/Network/Minio/PresignedOperations.hs
+++ b/src/Network/Minio/PresignedOperations.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 --
 -- MinIO Haskell SDK, (C) 2017 MinIO, Inc.
 --
@@ -50,6 +52,10 @@ import Network.Minio.Data.Time
 import Network.Minio.Errors
 import Network.Minio.Sign.V4
 import Network.URI (uriToString)
+
+#if MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson.Key as A
+#endif
 
 -- | Generate a presigned URL. This function allows for advanced usage
 -- - for simple cases prefer the `presigned*Url` functions.
@@ -174,12 +180,20 @@ data PostPolicyCondition
 
 instance Json.ToJSON PostPolicyCondition where
   toJSON (PPCStartsWith k v) = Json.toJSON ["starts-with", k, v]
+#if MIN_VERSION_aeson(2,0,0)
+  toJSON (PPCEquals k v) = Json.object [(A.fromText k) .= v]
+#else
   toJSON (PPCEquals k v) = Json.object [k .= v]
+#endif
   toJSON (PPCRange k minVal maxVal) =
     Json.toJSON [Json.toJSON k, Json.toJSON minVal, Json.toJSON maxVal]
 
   toEncoding (PPCStartsWith k v) = Json.foldable ["starts-with", k, v]
+#if MIN_VERSION_aeson(2,0,0)
+  toEncoding (PPCEquals k v) = Json.pairs ((A.fromText k) .= v)
+#else
   toEncoding (PPCEquals k v) = Json.pairs (k .= v)
+#endif
   toEncoding (PPCRange k minVal maxVal) =
     Json.foldable [Json.toJSON k, Json.toJSON minVal, Json.toJSON maxVal]
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-18.24
+resolver: lts-19.7
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 587821
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/24.yaml
-    sha256: 06d844ba51e49907bd29cb58b4a5f86ee7587a4cd7e6cf395eeec16cba619ce8
-  original: lts-18.24
+    size: 618884
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/7.yaml
+    sha256: 57d4ce67cc097fea2058446927987bc1f7408890e3a6df0da74e5e318f051c20
+  original: lts-19.7


### PR DESCRIPTION
This PR adds support for Aeson 2, which became standard on Stackage resolvers in early February 2022.

Please let me know if you'd like me to update `ci.yml` also. I think it would make the most sense to add `9.0.2` and/or `9.2.2` to the "stack" matrix, since then it should be guaranteed to build against Aeson 2.