### PR TITLE
Add Credentials module to use Assume Role API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: mrkkrp/ormolu-action@v6
+      - uses: mrkkrp/ormolu-action@v8
 
   hlint:
     runs-on: ubuntu-latest

--- a/examples/AssumeRole.hs
+++ b/examples/AssumeRole.hs
@@ -1,0 +1,33 @@
+--
+-- MinIO Haskell SDK, (C) 2022 MinIO, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+{-# LANGUAGE OverloadedStrings #-}
+
+import Network.Minio.Credentials
+import Prelude
+
+main :: IO ()
+main = do
+  res <-
+    retrieveCredentials
+      $ STSAssumeRole
+        "https://play.min.io"
+        ( CredentialValue
+            "Q3AM3UQ867SPQQA43P2F"
+            "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
+            Nothing
+        )
+      $ defaultSTSAssumeRoleOptions {saroLocation = Just "us-east-1"}
+  print res

--- a/minio-hs.cabal
+++ b/minio-hs.cabal
@@ -128,6 +128,7 @@ common base-settings
                      , retry
                      , text >= 1.2
                      , time >= 1.9
+                     , time-units ^>= 1.0.0
                      , transformers >= 0.5
                      , unliftio >= 0.2 && < 0.3
                      , unliftio-core >= 0.2 && < 0.3
@@ -140,6 +141,7 @@ library
   exposed-modules:     Network.Minio
                      , Network.Minio.AdminAPI
                      , Network.Minio.S3API
+                     , Network.Minio.Credentials
 
 Flag live-test
   Description: Build the test suite that runs against a live MinIO server
@@ -339,3 +341,8 @@ executable SetConfig
   import:              examples-settings
   scope:               private
   main-is:             SetConfig.hs
+
+executable AssumeRole
+  import:              examples-settings
+  scope:               private
+  main-is:             AssumeRole.hs

--- a/src/Network/Minio/AdminAPI.hs
+++ b/src/Network/Minio/AdminAPI.hs
@@ -70,6 +70,7 @@ import Data.Aeson
   )
 import qualified Data.Aeson as A
 import Data.Aeson.Types (typeMismatch)
+import qualified Data.ByteArray as BA
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as T
@@ -95,9 +96,12 @@ data DriveInfo = DriveInfo
 instance FromJSON DriveInfo where
   parseJSON = withObject "DriveInfo" $ \v ->
     DriveInfo
-      <$> v .: "uuid"
-      <*> v .: "endpoint"
-      <*> v .: "state"
+      <$> v
+        .: "uuid"
+      <*> v
+        .: "endpoint"
+      <*> v
+        .: "state"
 
 data StorageClass = StorageClass
   { scParity :: Int,
@@ -120,12 +124,16 @@ instance FromJSON ErasureInfo where
     offlineDisks <- v .: "OfflineDisks"
     stdClass <-
       StorageClass
-        <$> v .: "StandardSCData"
-        <*> v .: "StandardSCParity"
+        <$> v
+          .: "StandardSCData"
+        <*> v
+          .: "StandardSCParity"
     rrClass <-
       StorageClass
-        <$> v .: "RRSCData"
-        <*> v .: "RRSCParity"
+        <$> v
+          .: "RRSCData"
+        <*> v
+          .: "RRSCParity"
     sets <- v .: "Sets"
     return $ ErasureInfo onlineDisks offlineDisks stdClass rrClass sets
 
@@ -151,8 +159,10 @@ data ConnStats = ConnStats
 instance FromJSON ConnStats where
   parseJSON = withObject "ConnStats" $ \v ->
     ConnStats
-      <$> v .: "transferred"
-      <*> v .: "received"
+      <$> v
+        .: "transferred"
+      <*> v
+        .: "received"
 
 data ServerProps = ServerProps
   { spUptime :: NominalDiffTime,
@@ -182,8 +192,10 @@ data StorageInfo = StorageInfo
 instance FromJSON StorageInfo where
   parseJSON = withObject "StorageInfo" $ \v ->
     StorageInfo
-      <$> v .: "Used"
-      <*> v .: "Backend"
+      <$> v
+        .: "Used"
+      <*> v
+        .: "Backend"
 
 data CountNAvgTime = CountNAvgTime
   { caCount :: Int64,
@@ -194,8 +206,10 @@ data CountNAvgTime = CountNAvgTime
 instance FromJSON CountNAvgTime where
   parseJSON = withObject "CountNAvgTime" $ \v ->
     CountNAvgTime
-      <$> v .: "count"
-      <*> v .: "avgDuration"
+      <$> v
+        .: "count"
+      <*> v
+        .: "avgDuration"
 
 data HttpStats = HttpStats
   { hsTotalHeads :: CountNAvgTime,
@@ -214,16 +228,26 @@ data HttpStats = HttpStats
 instance FromJSON HttpStats where
   parseJSON = withObject "HttpStats" $ \v ->
     HttpStats
-      <$> v .: "totalHEADs"
-      <*> v .: "successHEADs"
-      <*> v .: "totalGETs"
-      <*> v .: "successGETs"
-      <*> v .: "totalPUTs"
-      <*> v .: "successPUTs"
-      <*> v .: "totalPOSTs"
-      <*> v .: "successPOSTs"
-      <*> v .: "totalDELETEs"
-      <*> v .: "successDELETEs"
+      <$> v
+        .: "totalHEADs"
+      <*> v
+        .: "successHEADs"
+      <*> v
+        .: "totalGETs"
+      <*> v
+        .: "successGETs"
+      <*> v
+        .: "totalPUTs"
+      <*> v
+        .: "successPUTs"
+      <*> v
+        .: "totalPOSTs"
+      <*> v
+        .: "successPOSTs"
+      <*> v
+        .: "totalDELETEs"
+      <*> v
+        .: "successDELETEs"
 
 data SIData = SIData
   { sdStorage :: StorageInfo,
@@ -236,10 +260,14 @@ data SIData = SIData
 instance FromJSON SIData where
   parseJSON = withObject "SIData" $ \v ->
     SIData
-      <$> v .: "storage"
-      <*> v .: "network"
-      <*> v .: "http"
-      <*> v .: "server"
+      <$> v
+        .: "storage"
+      <*> v
+        .: "network"
+      <*> v
+        .: "http"
+      <*> v
+        .: "server"
 
 data ServerInfo = ServerInfo
   { siError :: Text,
@@ -251,9 +279,12 @@ data ServerInfo = ServerInfo
 instance FromJSON ServerInfo where
   parseJSON = withObject "ServerInfo" $ \v ->
     ServerInfo
-      <$> v .: "error"
-      <*> v .: "addr"
-      <*> v .: "data"
+      <$> v
+        .: "error"
+      <*> v
+        .: "addr"
+      <*> v
+        .: "data"
 
 data ServerVersion = ServerVersion
   { svVersion :: Text,
@@ -264,8 +295,10 @@ data ServerVersion = ServerVersion
 instance FromJSON ServerVersion where
   parseJSON = withObject "ServerVersion" $ \v ->
     ServerVersion
-      <$> v .: "version"
-      <*> v .: "commitID"
+      <$> v
+        .: "version"
+      <*> v
+        .: "commitID"
 
 data ServiceStatus = ServiceStatus
   { ssVersion :: ServerVersion,
@@ -306,9 +339,12 @@ data HealStartResp = HealStartResp
 instance FromJSON HealStartResp where
   parseJSON = withObject "HealStartResp" $ \v ->
     HealStartResp
-      <$> v .: "clientToken"
-      <*> v .: "clientAddress"
-      <*> v .: "startTime"
+      <$> v
+        .: "clientToken"
+      <*> v
+        .: "clientAddress"
+      <*> v
+        .: "startTime"
 
 data HealOpts = HealOpts
   { hoRecursive :: Bool,
@@ -325,8 +361,10 @@ instance ToJSON HealOpts where
 instance FromJSON HealOpts where
   parseJSON = withObject "HealOpts" $ \v ->
     HealOpts
-      <$> v .: "recursive"
-      <*> v .: "dryRun"
+      <$> v
+        .: "recursive"
+      <*> v
+        .: "dryRun"
 
 data HealItemType
   = HealItemMetadata
@@ -353,9 +391,12 @@ data NodeSummary = NodeSummary
 instance FromJSON NodeSummary where
   parseJSON = withObject "NodeSummary" $ \v ->
     NodeSummary
-      <$> v .: "name"
-      <*> v .: "errSet"
-      <*> v .: "errMsg"
+      <$> v
+        .: "name"
+      <*> v
+        .: "errSet"
+      <*> v
+        .: "errMsg"
 
 data SetConfigResult = SetConfigResult
   { scrStatus :: Bool,
@@ -366,8 +407,10 @@ data SetConfigResult = SetConfigResult
 instance FromJSON SetConfigResult where
   parseJSON = withObject "SetConfigResult" $ \v ->
     SetConfigResult
-      <$> v .: "status"
-      <*> v .: "nodeResults"
+      <$> v
+        .: "status"
+      <*> v
+        .: "nodeResults"
 
 data HealResultItem = HealResultItem
   { hriResultIdx :: Int,
@@ -388,16 +431,26 @@ data HealResultItem = HealResultItem
 instance FromJSON HealResultItem where
   parseJSON = withObject "HealResultItem" $ \v ->
     HealResultItem
-      <$> v .: "resultId"
-      <*> v .: "type"
-      <*> v .: "bucket"
-      <*> v .: "object"
-      <*> v .: "detail"
-      <*> v .:? "parityBlocks"
-      <*> v .:? "dataBlocks"
-      <*> v .: "diskCount"
-      <*> v .: "setCount"
-      <*> v .: "objectSize"
+      <$> v
+        .: "resultId"
+      <*> v
+        .: "type"
+      <*> v
+        .: "bucket"
+      <*> v
+        .: "object"
+      <*> v
+        .: "detail"
+      <*> v
+        .:? "parityBlocks"
+      <*> v
+        .:? "dataBlocks"
+      <*> v
+        .: "diskCount"
+      <*> v
+        .: "setCount"
+      <*> v
+        .: "objectSize"
       <*> ( do
               before <- v .: "before"
               before .: "drives"
@@ -420,12 +473,18 @@ data HealStatus = HealStatus
 instance FromJSON HealStatus where
   parseJSON = withObject "HealStatus" $ \v ->
     HealStatus
-      <$> v .: "Summary"
-      <*> v .: "StartTime"
-      <*> v .: "Settings"
-      <*> v .: "NumDisks"
-      <*> v .:? "Detail"
-      <*> v .: "Items"
+      <$> v
+        .: "Summary"
+      <*> v
+        .: "StartTime"
+      <*> v
+        .: "Settings"
+      <*> v
+        .: "NumDisks"
+      <*> v
+        .:? "Detail"
+      <*> v
+        .: "Items"
 
 healPath :: Maybe Bucket -> Maybe Text -> ByteString
 healPath bucket prefix = do
@@ -620,7 +679,8 @@ buildAdminRequest areq = do
       sp =
         SignParams
           (connectAccessKey ci)
-          (connectSecretKey ci)
+          (BA.convert (encodeUtf8 $ connectSecretKey ci :: ByteString))
+          ServiceS3
           timeStamp
           Nothing
           Nothing
@@ -630,7 +690,7 @@ buildAdminRequest areq = do
   -- Update signReq with Authorization header containing v4 signature
   return
     signReq
-      { NC.requestHeaders = ariHeaders newAreq ++ mkHeaderFromPairs signHeaders
+      { NC.requestHeaders = ariHeaders newAreq ++ signHeaders
       }
   where
     toRequest :: ConnectInfo -> AdminReqInfo -> NC.Request

--- a/src/Network/Minio/Credentials.hs
+++ b/src/Network/Minio/Credentials.hs
@@ -1,0 +1,144 @@
+--
+-- MinIO Haskell SDK, (C) 2017-2022 MinIO, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+module Network.Minio.Credentials
+  ( CredentialValue (..),
+    CredentialProvider (..),
+    AccessKey,
+    SecretKey,
+    SessionToken,
+    defaultSTSAssumeRoleOptions,
+    STSAssumeRole (..),
+    STSAssumeRoleOptions (..),
+  )
+where
+
+import qualified Data.Time as Time
+import Data.Time.Units (Second)
+import Network.HTTP.Client (RequestBody (RequestBodyBS))
+import qualified Network.HTTP.Client as NC
+import qualified Network.HTTP.Client.TLS as NC
+import Network.HTTP.Types (hContentType, methodPost, renderSimpleQuery)
+import Network.HTTP.Types.Header (hHost)
+import Network.Minio.Data
+import Network.Minio.Data.Crypto (hashSHA256)
+import Network.Minio.Sign.V4
+import Network.Minio.Utils (httpLbs)
+import Network.Minio.XmlParser (parseSTSAssumeRoleResult)
+
+class CredentialProvider p where
+  retrieveCredentials :: p -> IO CredentialValue
+
+stsVersion :: ByteString
+stsVersion = "2011-06-15"
+
+defaultDurationSeconds :: Second
+defaultDurationSeconds = 3600
+
+data STSAssumeRole = STSAssumeRole
+  { sarEndpoint :: Text,
+    sarCredentials :: CredentialValue,
+    sarOptions :: STSAssumeRoleOptions
+  }
+
+data STSAssumeRoleOptions = STSAssumeRoleOptions
+  { -- | Desired validity for the generated credentials.
+    saroDurationSeconds :: Maybe Second,
+    -- | IAM policy to apply for the generated credentials.
+    saroPolicyJSON :: Maybe ByteString,
+    -- | Location is usually required for AWS.
+    saroLocation :: Maybe Text,
+    saroRoleARN :: Maybe Text,
+    saroRoleSessionName :: Maybe Text,
+    -- | Optional HTTP connection manager
+    saroHTTPManager :: Maybe NC.Manager
+  }
+
+-- | Default STS Assume Role options
+defaultSTSAssumeRoleOptions :: STSAssumeRoleOptions
+defaultSTSAssumeRoleOptions =
+  STSAssumeRoleOptions
+    { saroDurationSeconds = Just defaultDurationSeconds,
+      saroPolicyJSON = Nothing,
+      saroLocation = Nothing,
+      saroRoleARN = Nothing,
+      saroRoleSessionName = Nothing,
+      saroHTTPManager = Nothing
+    }
+
+instance CredentialProvider STSAssumeRole where
+  retrieveCredentials sar = do
+    -- Assemble STS request
+    let requiredParams =
+          [ ("Action", "AssumeRole"),
+            ("Version", stsVersion)
+          ]
+        opts = sarOptions sar
+        durSecs :: Int =
+          fromIntegral $
+            fromMaybe defaultDurationSeconds $
+              saroDurationSeconds opts
+        otherParams =
+          [ ("RoleArn",) . encodeUtf8 <$> saroRoleARN opts,
+            ("RoleSessionName",) . encodeUtf8 <$> saroRoleSessionName opts,
+            Just ("DurationSeconds", show durSecs),
+            ("Policy",) <$> saroPolicyJSON opts
+          ]
+        parameters = requiredParams ++ catMaybes otherParams
+        (host, port, isSecure) =
+          let endPt = NC.parseRequest_ $ toString $ sarEndpoint sar
+           in (NC.host endPt, NC.port endPt, NC.secure endPt)
+        reqBody = renderSimpleQuery False parameters
+        req =
+          NC.defaultRequest
+            { NC.host = host,
+              NC.port = port,
+              NC.secure = isSecure,
+              NC.method = methodPost,
+              NC.requestHeaders =
+                [ (hHost, getHostHeader (host, port)),
+                  (hContentType, "application/x-www-form-urlencoded")
+                ],
+              NC.requestBody = RequestBodyBS reqBody
+            }
+
+    -- Sign the STS request.
+    timeStamp <- liftIO Time.getCurrentTime
+    let sp =
+          SignParams
+            { spAccessKey = coerce $ cvAccessKey $ sarCredentials sar,
+              spSecretKey = coerce $ cvSecretKey $ sarCredentials sar,
+              spService = ServiceSTS,
+              spTimeStamp = timeStamp,
+              spRegion = saroLocation opts,
+              spExpirySecs = Nothing,
+              spPayloadHash = Just $ hashSHA256 reqBody
+            }
+        signHeaders = signV4 sp req
+        signedReq =
+          req
+            { NC.requestHeaders = NC.requestHeaders req ++ signHeaders
+            }
+        settings = bool NC.defaultManagerSettings NC.tlsManagerSettings isSecure
+
+    -- Make the STS request
+    mgr <- maybe (NC.newManager settings) return $ saroHTTPManager opts
+    resp <- httpLbs signedReq mgr
+    result <-
+      parseSTSAssumeRoleResult
+        (toStrict $ NC.responseBody resp)
+        "https://sts.amazonaws.com/doc/2011-06-15/"
+    return $ arcCredentials $ arrRoleCredentials result

--- a/test/LiveServer.hs
+++ b/test/LiveServer.hs
@@ -279,7 +279,8 @@ lowLevelMultipartTest = funTestWithBucket "Low-level Multipart Test" $
     fGetObject bucket object destFile defaultGetObjectOptions
     gotSize <- withNewHandle destFile getFileSize
     liftIO $
-      gotSize == Right (Just mb15)
+      gotSize
+        == Right (Just mb15)
         @? "Wrong file size of put file after getting"
 
     step "Cleanup actions"
@@ -303,7 +304,8 @@ putObjectSizeTest = funTestWithBucket "PutObject of conduit source with size" $
     fGetObject bucket obj destFile defaultGetObjectOptions
     gotSize <- withNewHandle destFile getFileSize
     liftIO $
-      gotSize == Right (Just mb1)
+      gotSize
+        == Right (Just mb1)
         @? "Wrong file size of put file after getting"
 
     step "Cleanup actions"
@@ -327,7 +329,8 @@ putObjectNoSizeTest = funTestWithBucket "PutObject of conduit source with no siz
     fGetObject bucket obj destFile defaultGetObjectOptions
     gotSize <- withNewHandle destFile getFileSize
     liftIO $
-      gotSize == Right (Just mb70)
+      gotSize
+        == Right (Just mb70)
         @? "Wrong file size of put file after getting"
 
     step "Cleanup actions"
@@ -569,6 +572,7 @@ presignedUrlFunTest = funTestWithBucket "presigned Url tests" $
         []
         []
 
+    print putUrl
     let size1 = 1000 :: Int64
     inputFile <- mkRandFile size1
 
@@ -1176,7 +1180,8 @@ getNPutSSECTest =
 
         gotSize <- withNewHandle dstFile getFileSize
         liftIO $
-          gotSize == Right (Just mb1)
+          gotSize
+            == Right (Just mb1)
             @? "Wrong file size of object when getting"
 
         step "Cleanup"


### PR DESCRIPTION
This exports a new module for retrieving STS based credentials, however they are not yet convenient to use in the library - the session token needs to be included as a custom header and may not be possible with all APIs.