### PR TITLE
Use crypton-connection instead of connection

### DIFF
--- a/minio-hs.cabal
+++ b/minio-hs.cabal
@@ -114,7 +114,7 @@ common base-settings
                      , case-insensitive >= 1.2
                      , conduit >= 1.3
                      , conduit-extra >= 1.3
-                     , connection
+                     , crypton-connection
                      , cryptonite >= 0.25
                      , cryptonite-conduit >= 0.2
                      , digest >= 0.0.1


### PR DESCRIPTION
The connection package is not maintained anymore and doesn't work with GHC 9.6

I've found the crypton-connection fork via https://discourse.haskell.org/t/fork-of-archived-connection-a-k-a-hs-connection-library/8545