### PR TITLE
Add GHC 9.6 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,26 +24,26 @@ jobs:
   ormolu:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: haskell-actions/run-ormolu@v12
+      - uses: actions/checkout@v4
+      - uses: haskell-actions/run-ormolu@v15
         with:
           version: "0.5.0.1"
 
   hlint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-    - name: 'Set up HLint'
-      uses: haskell/actions/hlint-setup@v2
-      with:
-        version: '3.5'
+      - name: "Set up HLint"
+        uses: haskell/actions/hlint-setup@v2
+        with:
+          version: "3.5"
 
-    - name: 'Run HLint'
-      uses: haskell/actions/hlint-run@v2
-      with:
-        path: '["src/", "test/", "examples"]'
-        fail-on: warning
+      - name: "Run HLint"
+        uses: haskell/actions/hlint-run@v2
+        with:
+          path: '["src/", "test/", "examples"]'
+          fail-on: warning
 
   cabal:
     name: ${{ matrix.os }} / ghc-${{ matrix.ghc }} / cabal-${{ matrix.cabal }}
@@ -52,96 +52,95 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest] # Removed macos-latest due to cert issues.
-        cabal: ["3.6", "3.8", "latest"]
+        cabal: ["3.8", "latest"]
         ghc:
+          - "9.6"
           - "9.4"
           - "9.2"
           - "9.0"
           - "8.10"
-          - "8.8"
-          - "8.6"
-        exclude:
-          - os: windows-latest
-            ghc: "9.4"
-            cabal: "3.6"
+        # exclude:
+        #   - os: windows-latest
+        #     ghc: "9.4"
+        #     cabal: "3.6"
 
     steps:
-    - uses: actions/checkout@v3
-      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
+      - uses: actions/checkout@v4
+        if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: haskell/actions/setup@v2
-      id: setup-haskell-cabal
-      name: Setup Haskell
-      with:
-        ghc-version: ${{ matrix.ghc }}
-        cabal-version: ${{ matrix.cabal }}
+      - uses: haskell/actions/setup@v2
+        id: setup-haskell-cabal
+        name: Setup Haskell
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: ${{ matrix.cabal }}
 
-    - name: Configure
-      run: |
-        cabal configure --enable-tests --enable-benchmarks --test-show-details=direct -fexamples -fdev -flive-test
+      - name: Configure
+        run: |
+          cabal configure --enable-tests --enable-benchmarks --test-show-details=direct -fexamples -fdev -flive-test
 
-    - name: Freeze
-      run: |
-        cabal freeze
+      - name: Freeze
+        run: |
+          cabal freeze
 
-    - uses: actions/cache@v3
-      name: Cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
-      with:
-        path: |
-          ~/.cabal/packages
-          ~/.cabal/store
-          dist-newstyle
-        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}
-        restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
+      - uses: actions/cache@v3
+        name: Cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+            dist-newstyle
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
 
-    - name: Install dependencies
-      run: |
-        cabal build --only-dependencies
+      - name: Install dependencies
+        run: |
+          cabal build --only-dependencies
 
-    - name: Build
-      run: |
-        cabal build
+      - name: Build
+        run: |
+          cabal build
 
-    - name: Setup MinIO for testing (Linux)
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        mkdir -p /tmp/minio /tmp/minio-config/certs
-        cp test/cert/* /tmp/minio-config/certs/
-        (cd /tmp/minio; wget -q https://dl.min.io/server/minio/release/linux-amd64/minio; chmod +x ./minio)
-        sudo cp /tmp/minio-config/certs/public.crt /usr/local/share/ca-certificates/
-        sudo update-ca-certificates
+      - name: Setup MinIO for testing (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          mkdir -p /tmp/minio /tmp/minio-config/certs
+          cp test/cert/* /tmp/minio-config/certs/
+          (cd /tmp/minio; wget -q https://dl.min.io/server/minio/release/linux-amd64/minio; chmod +x ./minio)
+          sudo cp /tmp/minio-config/certs/public.crt /usr/local/share/ca-certificates/
+          sudo update-ca-certificates
 
-    - name: Setup MinIO for testing (MacOS)
-      if: matrix.os == 'macos-latest'
-      run: |
-        mkdir -p /tmp/minio /tmp/minio-config/certs
-        cp test/cert/* /tmp/minio-config/certs/
-        (cd /tmp/minio; wget -q https://dl.min.io/server/minio/release/darwin-amd64/minio; chmod +x ./minio)
-        sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /tmp/minio-config/certs/public.crt
+      - name: Setup MinIO for testing (MacOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          mkdir -p /tmp/minio /tmp/minio-config/certs
+          cp test/cert/* /tmp/minio-config/certs/
+          (cd /tmp/minio; wget -q https://dl.min.io/server/minio/release/darwin-amd64/minio; chmod +x ./minio)
+          sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /tmp/minio-config/certs/public.crt
 
-    - name: Setup MinIO for testing (Windows)
-      if: matrix.os == 'windows-latest'
-      run: |
-        New-Item -ItemType Directory -Path "$env:temp/minio-config/certs/"
-        Copy-Item -Path test\cert\* -Destination "$env:temp/minio-config/certs/"
-        Invoke-WebRequest -Uri https://dl.minio.io/server/minio/release/windows-amd64/minio.exe -OutFile $HOME/minio.exe
-        Import-Certificate -FilePath "$env:temp/minio-config/certs/public.crt" -CertStoreLocation Cert:\LocalMachine\Root
+      - name: Setup MinIO for testing (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          New-Item -ItemType Directory -Path "$env:temp/minio-config/certs/"
+          Copy-Item -Path test\cert\* -Destination "$env:temp/minio-config/certs/"
+          Invoke-WebRequest -Uri https://dl.minio.io/server/minio/release/windows-amd64/minio.exe -OutFile $HOME/minio.exe
+          Import-Certificate -FilePath "$env:temp/minio-config/certs/public.crt" -CertStoreLocation Cert:\LocalMachine\Root
 
-    - name: Test (Non-Windows)
-      if: matrix.os != 'windows-latest'
-      run: |
-        /tmp/minio/minio server --quiet --certs-dir /tmp/minio-config/certs data1 data2 data3 data4 2>&1 > minio.log &
-        ghc --version
-        cabal --version
-        cabal test
+      - name: Test (Non-Windows)
+        if: matrix.os != 'windows-latest'
+        run: |
+          /tmp/minio/minio server --quiet --certs-dir /tmp/minio-config/certs data1 data2 data3 data4 2>&1 > minio.log &
+          ghc --version
+          cabal --version
+          cabal test
 
-    - name: Test (Windows)
-      if: matrix.os == 'windows-latest'
-      run: |
-        Start-Process -NoNewWindow -FilePath "$HOME/minio.exe" -ArgumentList "--certs-dir", "$env:temp/minio-config/certs", "server", "$env:temp/data1", "$env:temp/data2", "$env:temp/data3", "$env:temp/data4"
-        ghc --version
-        cabal --version
-        cabal test
+      - name: Test (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          Start-Process -NoNewWindow -FilePath "$HOME/minio.exe" -ArgumentList "--certs-dir", "$env:temp/minio-config/certs", "server", "$env:temp/data1", "$env:temp/data2", "$env:temp/data3", "$env:temp/data4"
+          ghc --version
+          cabal --version
+          cabal test
 
   stack:
     name: stack / ghc ${{ matrix.ghc }}
@@ -151,80 +150,83 @@ jobs:
         ghc:
           - "8.10.7"
           - "9.0.2"
-          - "9.2.4"
+          - "9.2.8"
+          - "9.4.8"
+          - "9.6.5"
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v3
-      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
+      - uses: actions/checkout@v4
+        if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: haskell/actions/setup@v2
-      name: Setup Haskell Stack
-      with:
-        enable-stack: true
-        ghc-version: ${{ matrix.ghc }}
-        stack-version: 'latest'
+      - name: Install Haskell Stack
+        run: |
+          if ! which stack
+          then
+            curl -sSL https://get.haskellstack.org/ | sh
+          fi
 
-    - uses: actions/cache@v3
-      name: Cache ~/.stack
-      with:
-        path: ~/.stack
-        key: ${{ runner.os }}-stack-global-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-stack-global-
-    - uses: actions/cache@v3
-      name: Cache .stack-work
-      with:
-        path: .stack-work
-        key: ${{ runner.os }}-stack-work-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}-${{ hashFiles('**/*.hs') }}
-        restore-keys: |
-          ${{ runner.os }}-stack-work-
+      - uses: actions/cache@v3
+        name: Cache ~/.stack
+        with:
+          path: ~/.stack
+          key: ${{ runner.os }}-stack-global-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-stack-global-
+      - uses: actions/cache@v3
+        name: Cache .stack-work
+        with:
+          path: .stack-work
+          key: ${{ runner.os }}-stack-work-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}-${{ hashFiles('**/*.hs') }}
+          restore-keys: |
+            ${{ runner.os }}-stack-work-
 
-    - name: Install dependencies
-      run: |
-        stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks --only-dependencies
+      - name: Install dependencies
+        run: |
+          stack --version
+          stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks --only-dependencies
 
-    - name: Build
-      run: |
-        stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks --flag minio-hs:examples --flag minio-hs:live-test --flag minio-hs:dev
+      - name: Build
+        run: |
+          stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks --flag minio-hs:examples --flag minio-hs:live-test --flag minio-hs:dev
 
-    - name: Setup MinIO for testing (Linux)
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        mkdir -p /tmp/minio /tmp/minio-config/certs
-        cp test/cert/* /tmp/minio-config/certs/
-        (cd /tmp/minio; wget -q https://dl.min.io/server/minio/release/linux-amd64/minio; chmod +x ./minio)
-        sudo cp /tmp/minio-config/certs/public.crt /usr/local/share/ca-certificates/
-        sudo update-ca-certificates
+      - name: Setup MinIO for testing (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          mkdir -p /tmp/minio /tmp/minio-config/certs
+          cp test/cert/* /tmp/minio-config/certs/
+          (cd /tmp/minio; wget -q https://dl.min.io/server/minio/release/linux-amd64/minio; chmod +x ./minio)
+          sudo cp /tmp/minio-config/certs/public.crt /usr/local/share/ca-certificates/
+          sudo update-ca-certificates
 
-    - name: Setup MinIO for testing (MacOS)
-      if: matrix.os == 'macos-latest'
-      run: |
-        mkdir -p /tmp/minio /tmp/minio-config/certs
-        cp test/cert/* /tmp/minio-config/certs/
-        (cd /tmp/minio; wget -q https://dl.min.io/server/minio/release/darwin-amd64/minio; chmod +x ./minio)
-        sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /tmp/minio-config/certs/public.crt
+      - name: Setup MinIO for testing (MacOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          mkdir -p /tmp/minio /tmp/minio-config/certs
+          cp test/cert/* /tmp/minio-config/certs/
+          (cd /tmp/minio; wget -q https://dl.min.io/server/minio/release/darwin-amd64/minio; chmod +x ./minio)
+          sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /tmp/minio-config/certs/public.crt
 
-    - name: Setup MinIO for testing (Windows)
-      if: matrix.os == 'windows-latest'
-      run: |
-        New-Item -ItemType Directory -Path "$env:temp/minio-config/certs/"
-        Copy-Item -Path test\cert\* -Destination "$env:temp/minio-config/certs/"
-        Invoke-WebRequest -Uri https://dl.minio.io/server/minio/release/windows-amd64/minio.exe -OutFile $HOME/minio.exe
-        Import-Certificate -FilePath "$env:temp/minio-config/certs/public.crt" -CertStoreLocation Cert:\LocalMachine\Root
+      - name: Setup MinIO for testing (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          New-Item -ItemType Directory -Path "$env:temp/minio-config/certs/"
+          Copy-Item -Path test\cert\* -Destination "$env:temp/minio-config/certs/"
+          Invoke-WebRequest -Uri https://dl.minio.io/server/minio/release/windows-amd64/minio.exe -OutFile $HOME/minio.exe
+          Import-Certificate -FilePath "$env:temp/minio-config/certs/public.crt" -CertStoreLocation Cert:\LocalMachine\Root
 
-    - name: Test (Non-Windows)
-      if: matrix.os != 'windows-latest'
-      run: |
-        /tmp/minio/minio server --quiet --certs-dir /tmp/minio-config/certs data1 data2 data3 data4 2>&1 > minio.log &
-        ghc --version
-        stack --version
-        stack test --system-ghc --flag minio-hs:live-test --flag minio-hs:dev
+      - name: Test (Non-Windows)
+        if: matrix.os != 'windows-latest'
+        run: |
+          /tmp/minio/minio server --quiet --certs-dir /tmp/minio-config/certs data1 data2 data3 data4 2>&1 > minio.log &
+          ghc --version
+          stack --version
+          stack test --system-ghc --flag minio-hs:live-test --flag minio-hs:dev
 
-    - name: Test (Windows)
-      if: matrix.os == 'windows-latest'
-      run: |
-        Start-Process -NoNewWindow -FilePath "$HOME/minio.exe" -ArgumentList "--certs-dir", "$env:temp/minio-config/certs", "server", "$env:temp/data1", "$env:temp/data2", "$env:temp/data3", "$env:temp/data4"
-        ghc --version
-        cabal --version
-        stack test --system-ghc --flag minio-hs:live-test --flag minio-hs:dev
+      - name: Test (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          Start-Process -NoNewWindow -FilePath "$HOME/minio.exe" -ArgumentList "--certs-dir", "$env:temp/minio-config/certs", "server", "$env:temp/data1", "$env:temp/data2", "$env:temp/data3", "$env:temp/data4"
+          ghc --version
+          cabal --version
+          stack test --system-ghc --flag minio-hs:live-test --flag minio-hs:dev

--- a/minio-hs.cabal
+++ b/minio-hs.cabal
@@ -22,12 +22,11 @@ extra-doc-files:
 extra-source-files:
                    examples/*.hs
                    stack.yaml
-tested-with:         GHC == 8.6.5
-                   , GHC == 8.8.4
-                   , GHC == 8.10.7
+tested-with:  GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.7
-                   , GHC == 9.4.5
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.5
 
 source-repository head
   type:                git

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-19.7
+resolver: lts-22.19
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -36,17 +36,17 @@ resolver: lts-19.7
 # non-dependency (i.e. a user package), and its test suites and benchmarks
 # will not be run. This is useful for tweaking upstream packages.
 packages:
-- '.'
+  - "."
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+  - crypton-connection-0.3.2
 
 # Override default flag values for local packages and extra-deps
 flags: {}
 
 # Extra package databases containing global packages
 extra-package-dbs: []
-
 # Control whether we use the GHC we find on the path
 # system-ghc: true
 #

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,10 +3,17 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: crypton-connection-0.3.2@sha256:c7937edc25ab022bcf167703f2ec5ab73b62908e545bb587d2aa42b33cd6f6cc,1581
+    pantry-tree:
+      sha256: f986ad29b008cbe5732606e9cde1897191c486a2f1f169a4cb75fd915bce397c
+      size: 394
+  original:
+    hackage: crypton-connection-0.3.2
 snapshots:
 - completed:
-    size: 618884
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/7.yaml
-    sha256: 57d4ce67cc097fea2058446927987bc1f7408890e3a6df0da74e5e318f051c20
-  original: lts-19.7
+    sha256: e5cac927cf7ccbd52aa41476baa68b88c564ee6ddc3bc573dbf4210069287fe7
+    size: 713340
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/19.yaml
+  original: lts-22.19


### PR DESCRIPTION
    Tests needing fixing for recent minio
    
    Also:
    - set minimum tested version to 8.10
    - remove building with cabal 3.6
    - update stack.yaml to add crypton-connection
    
    Update live server test env var handling
