### PR TITLE
Compatibility with crypton-connection >= 0.4.0

### DIFF
--- a/minio-hs.cabal
+++ b/minio-hs.cabal
@@ -117,6 +117,7 @@ common base-settings
                      , crypton-connection
                      , cryptonite >= 0.25
                      , cryptonite-conduit >= 0.2
+                     , data-default-class
                      , digest >= 0.0.1
                      , directory
                      , filepath >= 1.4

--- a/src/Network/Minio/Data.hs
+++ b/src/Network/Minio/Data.hs
@@ -35,6 +35,7 @@ import qualified Data.Aeson as A
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as LB
+import Data.Default.Class (def)
 import qualified Data.HashMap.Strict as H
 import qualified Data.Ini as Ini
 import qualified Data.List as List
@@ -1115,7 +1116,11 @@ connect :: ConnectInfo -> IO MinioConn
 connect ci = do
   let settings
         | connectIsSecure ci && connectDisableTLSCertValidation ci =
-            let badTlsSettings = Conn.TLSSettingsSimple True False False
+            let badTlsSettings =
+                  case def of
+                    tlsSettings@Conn.TLSSettingsSimple {} ->
+                      tlsSettings {Conn.settingDisableCertificateValidation = True}
+                    _ -> def
              in TLS.mkManagerSettings badTlsSettings Nothing
         | connectIsSecure ci = NC.tlsManagerSettings
         | otherwise = defaultManagerSettings


### PR DESCRIPTION
crypton-connection versions >= 0.4.0 [added a new field](https://github.com/kazu-yamamoto/crypton-connection/pull/3) to `TLSConnectionSettings`. This broke some code in `minio-hs` that didn't supply the new field. This PR addresses that by using the `def` value for `TLSSettings` which is the same as the one that minio-hs was creating except for one pre-existing field. By using `def` the code should remain compatible with `crypton-connection` versions < 0.4.0 too.