### PR TITLE
Add IfNoneMatch for PUT req

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ cabal.sandbox.config
 .stack-work/
 cabal.project.local
 *~
+tags
+tags.mtime

--- a/src/Network/Minio.hs
+++ b/src/Network/Minio.hs
@@ -151,6 +151,7 @@ module Network.Minio
     pooUserMetadata,
     pooNumThreads,
     pooSSE,
+    pooIfNoneMatch,
     getObject,
     GetObjectOptions,
     defaultGetObjectOptions,

--- a/src/Network/Minio/Data.hs
+++ b/src/Network/Minio/Data.hs
@@ -373,12 +373,14 @@ data PutObjectOptions = PutObjectOptions
     -- | Set number of worker threads used to upload an object.
     pooNumThreads :: Maybe Word,
     -- | Set object encryption parameters for the request.
-    pooSSE :: Maybe SSE
+    pooSSE :: Maybe SSE,
+    -- | Set a behavior to put object with name already existed in storage.
+    pooIfNoneMatch :: Maybe Text
   }
 
 -- | Provide default `PutObjectOptions`.
 defaultPutObjectOptions :: PutObjectOptions
-defaultPutObjectOptions = PutObjectOptions Nothing Nothing Nothing Nothing Nothing Nothing [] Nothing Nothing
+defaultPutObjectOptions = PutObjectOptions Nothing Nothing Nothing Nothing Nothing Nothing [] Nothing Nothing Nothing
 
 pooToHeaders :: PutObjectOptions -> [HT.Header]
 pooToHeaders poo =
@@ -395,7 +397,8 @@ pooToHeaders poo =
         "content-disposition",
         "content-language",
         "cache-control",
-        "x-amz-storage-class"
+        "x-amz-storage-class",
+        "if-none-match"
       ]
     values =
       map
@@ -405,7 +408,8 @@ pooToHeaders poo =
           pooContentDisposition,
           pooContentLanguage,
           pooCacheControl,
-          pooStorageClass
+          pooStorageClass,
+          pooIfNoneMatch
         ]
 
 -- |


### PR DESCRIPTION
Add an option pooIfNoneMatch in PutObjectOptions to control behaviour in case of putting object with already existed name

https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#API_PutObject_RequestSyntax